### PR TITLE
Added "odoo_core_modules" ansible var to list the core modules to be installed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,6 @@ odoo_log_level: warn
 odoo_db_name: odoo
 # This not a DB user password, but a password for Odoo to allow Odoo deal with DB.
 odoo_db_admin_password: iT0ohDuoth6ONgahDeepaich0aeka5ul
+
+# Comma-separated list of modules to install before running the server
+odoo_core_modules: "base"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -116,6 +116,6 @@
 - name: Init Odoo database
   become: yes
   become_user: "{{ odoo_default_user }}"
-  command: "{{ odoo_python_path }} {{ odoo_bin_path }} -c {{ odoo_config_path }}/odoo.conf -d {{ odoo_db_name }} --init base --stop-after-init"
+  command: "{{ odoo_python_path }} {{ odoo_bin_path }} -c {{ odoo_config_path }}/odoo.conf -d {{ odoo_db_name }} --init {{ odoo_core_modules }} --stop-after-init"
 
 - import_tasks: add-service.yml


### PR DESCRIPTION
Added `odoo_core_modules`, comma-separated list of modules to install before running the server.

Ex:
```YAML
odoo_core_modules: "base,i18n_es,account,project"
```

Default value only has `base` module