### PR TITLE
Uses Python3 (3.5) instead of Python2.7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
 odoo_role_odoo_head: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
 
 odoo_role_odoo_path: /opt/odoo
-odoo_role_odoo_bin_path: "{{ odoo_path }}/odoo-bin"
+odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/odoo-bin"
 odoo_role_odoo_python_path: "{{ odoo_role_odoo_venv_path }}/bin/python"
 odoo_role_odoo_config_path: /etc/odoo
 odoo_role_odoo_modules_path: /opt/odoo_modules

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
 odoo_role_odoo_head: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
 
 odoo_role_odoo_path: /opt/odoo
-odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/build/scripts-2.7/odoo"
+odoo_role_odoo_bin_path: "{{ odoo_path }}/odoo-bin"
 odoo_role_odoo_python_path: "{{ odoo_role_odoo_venv_path }}/bin/python"
 odoo_role_odoo_config_path: /etc/odoo
 odoo_role_odoo_modules_path: /opt/odoo_modules

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
   with_items:
     - build-essential
     - python-dev
+    - python3-dev
     - libxml2
     - libxml2-dev
     - libxslt1-dev

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -6,7 +6,7 @@
     pkg: "{{ item }}"
     state: present
   with_items:
-    - virtualenv
+    - python3-venv
 
 - name: Create virtualenv directory
   become: yes
@@ -22,7 +22,7 @@
   register: env
 
 - name: Manually create the initial virtualenv
-  command: "virtualenv {{ odoo_role_odoo_venv_path }}"
+  command: "python3 -m venv {{ odoo_role_odoo_venv_path }}"
   when: env.stat.isdir is undefined
 
 - name: Change virtualenv permissions


### PR DESCRIPTION
* Uses Python3 with `venv`: https://docs.python.org/3/library/venv.html 
* Execute Odoo from `odoo-bin` binary of the repository.