### PR TITLE
Use OCA nightly builds

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,23 +6,18 @@ odoo_role_odoo_group: odoo
 # VirtualEnv vars
 odoo_role_odoo_venv_path: /opt/.odoo_venv
 
+# Odoo nightly edition:
+#   official: odoo
+#   OCA:      oca
 odoo_role_odoo_edition: oca
-
-# Edition vars
-# Vars for the Odoo Nightly edition
-# odoo_role_odoo_edition: "odoo"
+odoo_role_nightly_url: "https://nightly.odoo.com/{{ odoo_role_odoo_version }}/nightly/src/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
+odoo_role_oca_nightly_url: "https://wheelhouse.odoo-community.org/ocb-nightly/{{ odoo_role_odoo_version }}/src/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
 odoo_role_odoo_version: 11.0
-odoo_role_odoo_release: 20170914
-odoo_role_odoo_url: "https://nightly.odoo.com/{{ odoo_role_odoo_version }}/nightly/src/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
+odoo_role_odoo_release: latest
 odoo_role_odoo_download_path: "/tmp/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
 
-# Vars for the OCA/OCB edition
-# odoo_role_odoo_edition: "oca"
-odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
-odoo_role_odoo_head: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
-
 odoo_role_odoo_path: /opt/odoo
-odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/odoo-bin"
+odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/build/scripts-3.5/odoo"
 odoo_role_odoo_python_path: "{{ odoo_role_odoo_venv_path }}/bin/python"
 odoo_role_odoo_config_path: /etc/odoo
 odoo_role_odoo_modules_path: /opt/odoo_modules

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,12 +1,22 @@
 ---
-# Odoo from the Odoo Nightly: http://nightly.odoo.com/
+- name: Set official nightly URL
+  set_fact:
+    odoo_role_odoo_url: "{{ odoo_role_nightly_url }}"
+  when:
+    odoo_role_odoo_edition == "odoo"
+
+- name: Set OCA nightly URL
+  set_fact:
+    odoo_role_odoo_url: "{{ odoo_role_oca_nightly_url }}"
+  when:
+    odoo_role_odoo_edition == "oca"
+
 - name: Download Odoo
   get_url:
     url: "{{ odoo_role_odoo_url }}"
     dest: "{{ odoo_role_odoo_download_path }}"
     owner: "{{ odoo_role_odoo_user }}"
     group: "{{ odoo_role_odoo_group }}"
-  when: odoo_role_odoo_edition == "odoo"
 
 - name: Uncompress downloaded Odoo
   unarchive:
@@ -16,24 +26,4 @@
     owner: "{{ odoo_role_odoo_user }}"
     group: "{{ odoo_role_odoo_group }}"
     extra_opts: [--strip-components=1]
-    creates: "{{ odoo_role_odoo_path }}/setup.py"
-  when: odoo_role_odoo_edition  == "odoo"
-
-# Odoo from the OCA/OCB repository: https://github.com/OCA/OCB
-- name: "Git clone Odoo branch {{ odoo_role_odoo_version }}"
-  become_user: "{{ odoo_role_odoo_user }}"
-  git:
-    repo: "{{ odoo_role_odoo_git_url }}"
-    dest: "{{ odoo_role_odoo_path }}"
-    version: "{{ odoo_role_odoo_version }}"
-    depth: 1
-  when: odoo_role_odoo_edition == "oca"
-
-- name: "Git checkout to the head {{ odoo_role_odoo_head }}"
-  become_user: "{{ odoo_role_odoo_user }}"
-  git:
-    clone: no
-    repo: "{{ odoo_role_odoo_git_url }}"
-    dest: "{{ odoo_role_odoo_path }}"
-    version: "{{ odoo_role_odoo_head }}"
-  when: odoo_role_odoo_edition == "oca"
+    #creates: "{{ odoo_role_odoo_path }}/setup.py"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,7 +99,7 @@
     dest: "{{ odoo_role_odoo_config_path }}/odoo.conf"
     mode: 0774
     owner: "{{ odoo_role_odoo_user }}"
-    group: "{{  odoo_role_odoo_group }}"
+    group: "{{ odoo_role_odoo_group }}"
 
 - name: Init Odoo database
   become: yes


### PR DESCRIPTION
## WAT
Downloading OCB from git repository was starting to get too slow and generating issues like https://github.com/coopdevs/odoo-role/issues/22. After a search in GitHub I found out that the OCA is also maintaining a nightly build for OCB https://github.com/OCA/OCB/issues/718.

This is really interesting since it will speed up provisioning and also simplify our processes since we use the same strategy for both the official and OCA nightly builds.

## TODO
 - [ ] Add edition namespace to downloaded compressed file in `/tmp`