### PR TITLE
Remove unneeded git checkout task in OCA/OCB download

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ This role allows to install Odoo in two editions: [Odoo Nightly](http://nightly.
     # Vars for the OCA/OCB edition
     # odoo_role_odoo_edition: "oca"
     odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
-    odoo_role_odoo_head: "8ef3986d58a097a04502d9ca1ee0a860d7230723"     # Use the commit SHA of the required version
+    # Use the commit SHA of the required version
+    odoo_role_odoo_head: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
 
 * Users and group
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This role allows to install Odoo in two editions: [Odoo Nightly](http://nightly.
     # Vars for the OCA/OCB edition
     # odoo_role_odoo_edition: "oca"
     odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
-    odoo_role_odoo_head: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
+    odoo_role_odoo_head: "8ef3986d58a097a04502d9ca1ee0a860d7230723"     # Use the commit SHA of the required version
 
 * Users and group
 

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -28,12 +28,3 @@
     version: "{{ odoo_role_odoo_version }}"
     depth: 1
   when: odoo_role_odoo_edition == "oca"
-
-- name: "Git checkout to the head {{ odoo_role_odoo_head }}"
-  become_user: "{{ odoo_role_odoo_user }}"
-  git:
-    clone: no
-    repo: "{{ odoo_role_odoo_git_url }}"
-    dest: "{{ odoo_role_odoo_path }}"
-    version: "{{ odoo_role_odoo_head }}"
-  when: odoo_role_odoo_edition == "oca"


### PR DESCRIPTION
Remove the unneeded checkout task after the clone the OCA/OCB repository task.

The clone task downloads only the required branch in the commit required as `version`.

After this task, we don't need checkout to another commit because we already are in the desired point.