### PR TITLE
Feature/manage community roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ Community Roles
 ---------------
 
 #### Deploy
-To use community roles, you need deploy this modules in the server. This role manage the modules deployment with `pip`.
+To use community roles, you need to deploy this modules in the server. This role manage the modules deployment with `pip`.
 
 You can define a `requirements.txt` file to manage the modules and ensure the version installed:
 
 ```
-# requeriments.txt
+# requirements.txt
 odoo11-addon-contract==11.0.2.1.0
 odoo11-addon-contract-sale-invoicing==11.0.1.0.0
 odoo11-addon-contract-variable-qty-timesheet==11.0.1.0.0
@@ -86,7 +86,7 @@ odoo11-addon-contract-variable-quantity==11.0.1.2.1
 > The default the `requirements.txt` file path is `"{{ inventory_dir }}/../files/requirements.txt"`.
 
 # Install
-Once the modules are in the server, you need install them in the database.
+Once the modules are in the server, you need to install them in the database.
 
 Define a `odoo_role_odoo_community_modules` var with the list of the modules names you want to install.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 An Odoo Ansible Provisioning Role
 =========================================
 
-This an ansible role for provisioning Odoo. It has been tested with Odoo 10 and Odoo 11, but it's probably suitable for Odoo 11+ versions.
+This an Ansible role for provisioning Odoo. It has been tested with Odoo 10 and Odoo 11, but it's probably suitable for Odoo 11+ versions.
 
 Requirements
 ------------
 
 A PostgreSQL(9.5+).
 
-By now this role only supports peer authentication for postgreSQL database access.
+By now this role only supports peer authentication for PostgreSQL database access.
 
 So you need to create a database in PostgreSQL, one user with access to that database, and one system user with same username.
 
@@ -57,10 +57,43 @@ This role allows to install Odoo in two editions: [Odoo Nightly](http://nightly.
     # This not a DB user password, but a password for Odoo to deal with DB.
     odoo_role_odoo_db_admin_password: 1234
 
-* Core modules list to install
+* Core modules list to install/update
 
     # Comma-separated list of modules to install before running the server
     odoo_role_odoo_core_modules: "base"
+
+* Community modules list to install/update
+
+    # Comma-separated list of modules to install before running the server
+    odoo_role_odoo_community_modules: ""
+
+Community Roles
+---------------
+
+#### Deploy
+To use community roles, you need deploy this modules in the server. This role manage the modules deployment with `pip`.
+
+You can define a `requirements.txt` file to manage the modules and ensure the version installed:
+
+```
+# requeriments.txt
+odoo11-addon-contract==11.0.2.1.0
+odoo11-addon-contract-sale-invoicing==11.0.1.0.0
+odoo11-addon-contract-variable-qty-timesheet==11.0.1.0.0
+odoo11-addon-contract-variable-quantity==11.0.1.2.1
+```
+
+> The default the `requirements.txt` file path is `"{{ inventory_dir }}/../files/requirements.txt"`.
+
+# Install
+Once the modules are in the server, you need install them in the database.
+
+Define a `odoo_role_odoo_community_modules` var with the list of the modules names you want to install.
+
+```
+# invenotry/group_vars/all.yml
+odoo_role_odoo_community_modules: 'contract,contract_sale_invoicing'
+```
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,5 @@ odoo_role_odoo_db_admin_password: iT0ohDuoth6ONgahDeepaich0aeka5ul
 
 # Comma-separated list of modules to install before running the server
 odoo_role_odoo_core_modules: "base"
+
+odoo_daemon: "odoo.service"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,6 @@
 ---
 # handlers file for odoo
+- name: restart odoo
+  service:
+    name: "{{ odoo_daemon }}"
+    state: restarted

--- a/tasks/add-service.yml
+++ b/tasks/add-service.yml
@@ -11,13 +11,8 @@
 - name: Enable service
   become: yes
   systemd:
-    name: odoo.service
+    name: "{{ odoo_daemon }}"
     enabled: yes
     state: started
     daemon_reload: yes
-
-- name: Restart Odoo service
-  become: yes
-  service:
-    name: odoo
-    state: restarted
+  notify: restart odoo

--- a/tasks/community-modules.yml
+++ b/tasks/community-modules.yml
@@ -1,0 +1,22 @@
+---
+- name: Copy requirements.txt
+  copy:
+    src: "{{ inventory_dir }}/../files/requirements.txt"
+    dest: "{{ odoo_role_odoo_modules_path }}/requirements.txt"
+    owner: "{{ odoo_role_odoo_user }}"
+    group: "{{ odoo_role_odoo_group }}"
+
+- name: Deploy community roles with pip
+  pip:
+    requirements: "{{ odoo_role_odoo_modules_path }}/requirements.txt"
+    virtualenv: "{{ odoo_role_odoo_venv_path }}"
+
+- name: Update Odoo modules list
+  become: yes
+  become_user: "{{ odoo_role_odoo_user }}"
+  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --update all --stop-after-init --without-demo=all"
+
+- name: Install community Odoo roles
+  become: yes
+  become_user: "{{ odoo_role_odoo_user }}"
+  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_odoo_modules }} --stop-after-init --without-demo=all"

--- a/tasks/community-modules.yml
+++ b/tasks/community-modules.yml
@@ -19,4 +19,5 @@
 - name: Install community Odoo roles
   become: yes
   become_user: "{{ odoo_role_odoo_user }}"
-  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_odoo_modules }} --stop-after-init --without-demo=all"
+  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_community_odoo_modules }} --stop-after-init --without-demo=all"
+  notify: restart odoo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,11 +105,13 @@
     mode: 0774
     owner: "{{ odoo_role_odoo_user }}"
     group: "{{  odoo_role_odoo_group }}"
+  notify: restart odoo
 
 - name: Init Odoo database
   become: yes
   become_user: "{{ odoo_role_odoo_user }}"
   command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_odoo_core_modules }} --stop-after-init --without-demo=all"
+  notify: restart odoo
 
 - import_tasks: community-modules.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,9 @@
   with_items:
     - build-essential
     - python-dev
+    - python-setuptools
     - python3-dev
+    - python3-setuptools
     - libxml2
     - libxml2-dev
     - libxslt1-dev
@@ -108,5 +110,7 @@
   become: yes
   become_user: "{{ odoo_role_odoo_user }}"
   command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_odoo_core_modules }} --stop-after-init --without-demo=all"
+
+- import_tasks: community-modules.yml
 
 - import_tasks: add-service.yml


### PR DESCRIPTION
Install Odoo community roles manage by Pypi with `pip`.

Manage the `requirements.txt` in the inventory repo and set the variable `odoo_role_odoo_community_modules` with a list of modules to install/update.

Fix issue #32 

