### PR TITLE
Ignore error in the NodeJS symlink task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,12 +79,14 @@
     version: 2.7.2
     global: yes
 
+# This link is needed in Ubuntu 16.04 and in Ubuntu 18.04 raise and error.
 - name: Create node symlink
   become: yes
   file:
     src: /usr/bin/nodejs
     dest: /usr/bin/node
     state: link
+  ignore_errors: yes
 
 - name: Get installed Odoo version (if any)
   shell: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} --version | cut -d ' ' -f 3"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,7 @@
     src: /usr/bin/nodejs
     dest: /usr/bin/node
     state: link
-  ignore_errors: yes
+  when: ansible_distribution == "Ubuntu" and not ansible_distribution_version == "18.04"
 
 - name: Get installed Odoo version (if any)
   shell: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} --version | cut -d ' ' -f 3"


### PR DESCRIPTION
In Ubuntu 18.04 the NodeJS binary is called `node` instead of `nodejs`.
Fix #33