### PR TITLE
Enable the Odoo service start at boot

### DIFF
--- a/templates/odoo.service.j2
+++ b/templates/odoo.service.j2
@@ -17,3 +17,6 @@ RestartSec=5
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=odoo
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Documentation:
https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Examples
Example 1. Allowing units to be enabled

Fix #28