### PR TITLE
Fix warning on apt syntax deprecation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,21 +5,20 @@
   become: yes
   apt:
     update_cache: yes
-    pkg: "{{ item }}"
+    pkg:
+      - build-essential
+      - python-dev
+      - python-setuptools
+      - python3-dev
+      - python3-setuptools
+      - libxml2
+      - libxml2-dev
+      - libxslt1-dev
+      - libssl-dev
+      - libldap2-dev
+      - libsasl2-dev
+      - git
     state: present
-  with_items:
-    - build-essential
-    - python-dev
-    - python-setuptools
-    - python3-dev
-    - python3-setuptools
-    - libxml2
-    - libxml2-dev
-    - libxslt1-dev
-    - libssl-dev
-    - libldap2-dev
-    - libsasl2-dev
-    - git
 
 - name: Install wkhtmltopdf
   apt:
@@ -66,11 +65,10 @@
 - name: Install nodejs packages
   become: yes
   apt:
-    pkg: "{{ item }}"
+    pkg:
+      - nodejs
+      - npm
     state: present
-  with_items:
-    - nodejs
-    - npm
 
 - name: Install Less CSS via nodejs
   become: yes

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -3,10 +3,8 @@
   become: yes
   apt:
     update_cache: yes
-    pkg: "{{ item }}"
+    pkg: python3-venv
     state: present
-  with_items:
-    - python3-venv
 
 - name: Create virtualenv directory
   become: yes


### PR DESCRIPTION
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple
items and specifying `pkg: "{{ item }}"`,
please use `pkg: ['build-essential', 'python-dev', 'python3-dev',
'libxml2', 'libxml2-dev', 'libxslt1-dev', 'libssl-dev', 'libldap2-dev',
'libsasl2-dev', 'wkhtmltopdf', 'git']` and remove
the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.

Also: https://stackoverflow.com/questions/52743147/changing-ansible-loop-due-to-v2-11-deprecation