### PR TITLE
Optional demo data

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ odoo_role_odoo_modules_path: /opt/odoo/modules
 odoo_role_odoo_db_name: odoo
 # This not a DB user password, but a password for Odoo to deal with DB.
 odoo_role_odoo_db_admin_password: 1234
+# Whether to populate db with example data or not.
+# Use boolean values (True or False) instead of strings,
+#+ as "" is False, but non-empty strings as "True" and "False" are True.
+odoo_role_demo_data: False
 ```
 
 * Core modules list to install/update

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,8 @@ odoo_role_odoo_db_admin_password: iT0ohDuoth6ONgahDeepaich0aeka5ul
 odoo_role_odoo_core_modules: "base"
 
 odoo_daemon: "odoo.service"
+
+# Whether to populate db with example data or not.
+# Use boolean values (True or False) instead of strings,
+#+ as "" is False, but non-empty strings as "True" and "False" are True.
+odoo_role_demo_data: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,9 +20,16 @@
       - git
     state: present
 
-- name: Install wkhtmltopdf
+- name: Check if wkhtmltopdf is installed
+  shell: dpkg -s wkhtmltox | grep 'install ok installed'
+  register: wkhtmltox_installed
+  failed_when: false
+  changed_when: no
+
+- name: Download and install wkhtmltopdf only if not already present at any version
   apt:
     deb: "https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.{{ ansible_distribution_release }}_amd64.deb"
+  when: wkhtmltox_installed.rc == 1
 
 - import_tasks: virtualenv.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,7 +117,7 @@
 - name: Init Odoo database
   become: yes
   become_user: "{{ odoo_role_odoo_user }}"
-  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_odoo_core_modules }} --stop-after-init --without-demo=all"
+  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_odoo_core_modules }} --stop-after-init {{ '--without-demo-data=all' if not odoo_role_demo_data  }}"
   notify: restart odoo
 
 - import_tasks: community-modules.yml


### PR DESCRIPTION
Set up a variable that can be used from the playbook, inventory or command-line, to allow the decision to populate databases with demo data.

In the inventory
`odoo_role_demo_data: False`

On the cli
`ansible-playbook -i inventory/ --extra-vars "odoo_role_demo_data=True"`
see [the docs](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#passing-variables-on-the-command-line)

Right now I gotta go to `vendor/odoo-role/tasks/main.yml` , look up the line, comment, run, and remember to uncomment again when finished.