### PR TITLE
Skip download and install of wkhtmltox if present

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,9 +20,16 @@
       - git
     state: present
 
-- name: Install wkhtmltopdf
+- name: Check if wkhtmltopdf is installed
+  shell: dpkg -s wkhtmltox | grep 'install ok installed'
+  register: wkhtmltox_installed
+  failed_when: false
+  changed_when: no
+
+- name: Download and install wkhtmltopdf only if not already present at any version
   apt:
     deb: "https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.{{ ansible_distribution_release }}_amd64.deb"
+  when: wkhtmltox_installed.rc == 1
 
 - import_tasks: virtualenv.yml
 


### PR DESCRIPTION
Improves overall provisioning duration as downloading from remote sources takes a lot of time.

this part makes the check task idempotent
```yml
  failed_when: false
  changed_when: no
```
why? → https://symfonycasts.com/screencast/ansible/idempotency-changed-when