### PR TITLE
Create new variable and remove unused one

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,10 @@ odoo_role_odoo_download_path: "/tmp/odoo_{{ odoo_role_odoo_version }}.{{ odoo_ro
 # Vars for the OCA/OCB edition
 # odoo_role_odoo_edition: "oca"
 odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
-odoo_role_odoo_head: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
+# Not used
+# odoo_role_odoo_head: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
+# Must found a better ref
+odoo_role_git_ref: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
 
 odoo_role_odoo_path: /opt/odoo
 odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/odoo-bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,9 +19,7 @@ odoo_role_odoo_download_path: "/tmp/odoo_{{ odoo_role_odoo_version }}.{{ odoo_ro
 # Vars for the OCA/OCB edition
 # odoo_role_odoo_edition: "oca"
 odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
-# Not used
-# odoo_role_odoo_head: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
-# Must found a better ref
+# OCA/OCB, branch 11.0, June 11 2018
 odoo_role_git_ref: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
 
 odoo_role_odoo_path: /opt/odoo

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,17 +16,23 @@ odoo_role_odoo_release: 20170914
 odoo_role_odoo_url: "https://nightly.odoo.com/{{ odoo_role_odoo_version }}/nightly/src/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
 odoo_role_odoo_download_path: "/tmp/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
 
+# odoo_role_odoo_edition: coopdevs
+odoo_role_odoo_release: 11.0_2018-06-11
+odoo_role_odoo_url: "https://gitlab.com/coopdevs/OCB/-/archive/{{ odoo_role_odoo_release }}/OCB-{{ odoo_role_odoo_release }}.tar.gz"
+odoo_role_odoo_download_path: "/tmp/ocb-{{ odoo_role_odoo_release }}.tar.gz"
+
 # Vars for the OCA/OCB edition
 # odoo_role_odoo_edition: "oca"
 odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
 # OCA/OCB, branch 11.0, June 11 2018
-odoo_role_git_ref: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
+odoo_role_odoo_git_ref: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
 
 odoo_role_odoo_path: /opt/odoo
 odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/odoo-bin"
 odoo_role_odoo_python_path: "{{ odoo_role_odoo_venv_path }}/bin/python"
 odoo_role_odoo_config_path: /etc/odoo
 odoo_role_odoo_modules_path: /opt/odoo_modules
+odoo_role_odoo_version_file: "{{ odoo_role_odoo_path }}/.odoo_version.txt"
 
 odoo_role_odoo_log_path: /var/log/odoo
 odoo_role_odoo_log_level: debug
@@ -39,3 +45,4 @@ odoo_role_odoo_db_admin_password: iT0ohDuoth6ONgahDeepaich0aeka5ul
 odoo_role_odoo_core_modules: "base"
 
 odoo_daemon: "odoo.service"
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,23 +16,17 @@ odoo_role_odoo_release: 20170914
 odoo_role_odoo_url: "https://nightly.odoo.com/{{ odoo_role_odoo_version }}/nightly/src/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
 odoo_role_odoo_download_path: "/tmp/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
 
-# odoo_role_odoo_edition: coopdevs
-odoo_role_odoo_release: 11.0_2018-06-11
-odoo_role_odoo_url: "https://gitlab.com/coopdevs/OCB/-/archive/{{ odoo_role_odoo_release }}/OCB-{{ odoo_role_odoo_release }}.tar.gz"
-odoo_role_odoo_download_path: "/tmp/ocb-{{ odoo_role_odoo_release }}.tar.gz"
-
 # Vars for the OCA/OCB edition
 # odoo_role_odoo_edition: "oca"
 odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
 # OCA/OCB, branch 11.0, June 11 2018
-odoo_role_odoo_git_ref: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
+odoo_role_git_ref: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
 
 odoo_role_odoo_path: /opt/odoo
 odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/odoo-bin"
 odoo_role_odoo_python_path: "{{ odoo_role_odoo_venv_path }}/bin/python"
 odoo_role_odoo_config_path: /etc/odoo
 odoo_role_odoo_modules_path: /opt/odoo_modules
-odoo_role_odoo_version_file: "{{ odoo_role_odoo_path }}/.odoo_version.txt"
 
 odoo_role_odoo_log_path: /var/log/odoo
 odoo_role_odoo_log_level: debug
@@ -45,4 +39,3 @@ odoo_role_odoo_db_admin_password: iT0ohDuoth6ONgahDeepaich0aeka5ul
 odoo_role_odoo_core_modules: "base"
 
 odoo_daemon: "odoo.service"
-

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,61 +1,30 @@
 ---
-
-- name: Search hint to find out which Odoo version is installed
-  command: "cat {{ odoo_role_odoo_version_file }}"
-  register: odoo_installed_version
-  changed_when:
-    - odoo_installed_version.stdout != odoo_role_odoo_release
-    - odoo_installed_version.stdout != odoo_role_odoo_git_ref
-  failed_when: false
-
 # Odoo from the Odoo Nightly: http://nightly.odoo.com/
-- name: Download an Odoo release tar packet
-  block:
-  - name: Download Odoo
-    get_url:
-      url: "{{ odoo_role_odoo_url }}"
-      dest: "{{ odoo_role_odoo_download_path }}"
-      owner: "{{ odoo_role_odoo_user }}"
-      group: "{{ odoo_role_odoo_group }}"
-
-  - name: Uncompress downloaded Odoo
-    unarchive:
-      src: "{{ odoo_role_odoo_download_path }}"
-      dest: "{{ odoo_role_odoo_path }}"
-      remote_src: yes
-      owner: "{{ odoo_role_odoo_user }}"
-      group: "{{ odoo_role_odoo_group }}"
-      extra_opts: [--strip-components=1]
-
-  - set_fact: odoo_role_downloaded_version = "{{ odoo_role_odoo_release }}"
-
-  when:
-    - odoo_role_odoo_edition  == "odoo" or odoo_role_odoo_edition == "coopdevs"
-    - odoo_installed_version.changed
-
-
-# Odoo from the OCA/OCB repository: https://github.com/OCA/OCB
-- block:
-  - name: "Git clone git reference {{ odoo_role_odoo_git_ref }}"
-    become_user: "{{ odoo_role_odoo_user }}"
-    git:
-      repo: "{{ odoo_role_odoo_git_url }}"
-      dest: "{{ odoo_role_odoo_path }}"
-      version: "{{ odoo_role_odoo_git_ref }}"
-      depth: 1
-
-  - set_fact: odoo_role_downloaded_version = "{{ odoo_role_git_ref }}"
-
-  when:
-    - odoo_role_odoo_edition == "oca"
-    - odoo_installed_version.changed
-
-
-- name: Write down the version we just downloaded
-  copy:
-    content: "{{ odoo_role_odoo_release }}"
-    dest: "{{ odoo_role_odoo_version_file }}"
+- name: Download Odoo
+  get_url:
+    url: "{{ odoo_role_odoo_url }}"
+    dest: "{{ odoo_role_odoo_download_path }}"
     owner: "{{ odoo_role_odoo_user }}"
     group: "{{ odoo_role_odoo_group }}"
-    mode: 0644
+  when: odoo_role_odoo_edition == "odoo"
 
+- name: Uncompress downloaded Odoo
+  unarchive:
+    src: "{{ odoo_role_odoo_download_path }}"
+    dest: "{{ odoo_role_odoo_path }}"
+    remote_src: yes
+    owner: "{{ odoo_role_odoo_user }}"
+    group: "{{ odoo_role_odoo_group }}"
+    extra_opts: [--strip-components=1]
+    creates: "{{ odoo_role_odoo_path }}/setup.py"
+  when: odoo_role_odoo_edition  == "odoo"
+
+# Odoo from the OCA/OCB repository: https://github.com/OCA/OCB
+- name: "Git clone git reference {{ odoo_role_odoo_git_ref }}"
+  become_user: "{{ odoo_role_odoo_user }}"
+  git:
+    repo: "{{ odoo_role_odoo_git_url }}"
+    dest: "{{ odoo_role_odoo_path }}"
+    version: "{{ odoo_role_odoo_git_ref }}"
+    depth: 1
+  when: odoo_role_odoo_edition == "oca"

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -20,11 +20,11 @@
   when: odoo_role_odoo_edition  == "odoo"
 
 # Odoo from the OCA/OCB repository: https://github.com/OCA/OCB
-- name: "Git clone Odoo branch {{ odoo_role_odoo_version }}"
+- name: "Git clone git reference {{ odoo_role_odoo_git_ref }}"
   become_user: "{{ odoo_role_odoo_user }}"
   git:
     repo: "{{ odoo_role_odoo_git_url }}"
     dest: "{{ odoo_role_odoo_path }}"
-    version: "{{ odoo_role_odoo_version }}"
+    version: "{{ odoo_role_odoo_git_ref }}"
     depth: 1
   when: odoo_role_odoo_edition == "oca"

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,30 +1,61 @@
 ---
-# Odoo from the Odoo Nightly: http://nightly.odoo.com/
-- name: Download Odoo
-  get_url:
-    url: "{{ odoo_role_odoo_url }}"
-    dest: "{{ odoo_role_odoo_download_path }}"
-    owner: "{{ odoo_role_odoo_user }}"
-    group: "{{ odoo_role_odoo_group }}"
-  when: odoo_role_odoo_edition == "odoo"
 
-- name: Uncompress downloaded Odoo
-  unarchive:
-    src: "{{ odoo_role_odoo_download_path }}"
-    dest: "{{ odoo_role_odoo_path }}"
-    remote_src: yes
-    owner: "{{ odoo_role_odoo_user }}"
-    group: "{{ odoo_role_odoo_group }}"
-    extra_opts: [--strip-components=1]
-    creates: "{{ odoo_role_odoo_path }}/setup.py"
-  when: odoo_role_odoo_edition  == "odoo"
+- name: Search hint to find out which Odoo version is installed
+  command: "cat {{ odoo_role_odoo_version_file }}"
+  register: odoo_installed_version
+  changed_when:
+    - odoo_installed_version.stdout != odoo_role_odoo_release
+    - odoo_installed_version.stdout != odoo_role_odoo_git_ref
+  failed_when: false
+
+# Odoo from the Odoo Nightly: http://nightly.odoo.com/
+- name: Download an Odoo release tar packet
+  block:
+  - name: Download Odoo
+    get_url:
+      url: "{{ odoo_role_odoo_url }}"
+      dest: "{{ odoo_role_odoo_download_path }}"
+      owner: "{{ odoo_role_odoo_user }}"
+      group: "{{ odoo_role_odoo_group }}"
+
+  - name: Uncompress downloaded Odoo
+    unarchive:
+      src: "{{ odoo_role_odoo_download_path }}"
+      dest: "{{ odoo_role_odoo_path }}"
+      remote_src: yes
+      owner: "{{ odoo_role_odoo_user }}"
+      group: "{{ odoo_role_odoo_group }}"
+      extra_opts: [--strip-components=1]
+
+  - set_fact: odoo_role_downloaded_version = "{{ odoo_role_odoo_release }}"
+
+  when:
+    - odoo_role_odoo_edition  == "odoo" or odoo_role_odoo_edition == "coopdevs"
+    - odoo_installed_version.changed
+
 
 # Odoo from the OCA/OCB repository: https://github.com/OCA/OCB
-- name: "Git clone git reference {{ odoo_role_odoo_git_ref }}"
-  become_user: "{{ odoo_role_odoo_user }}"
-  git:
-    repo: "{{ odoo_role_odoo_git_url }}"
-    dest: "{{ odoo_role_odoo_path }}"
-    version: "{{ odoo_role_odoo_git_ref }}"
-    depth: 1
-  when: odoo_role_odoo_edition == "oca"
+- block:
+  - name: "Git clone git reference {{ odoo_role_odoo_git_ref }}"
+    become_user: "{{ odoo_role_odoo_user }}"
+    git:
+      repo: "{{ odoo_role_odoo_git_url }}"
+      dest: "{{ odoo_role_odoo_path }}"
+      version: "{{ odoo_role_odoo_git_ref }}"
+      depth: 1
+
+  - set_fact: odoo_role_downloaded_version = "{{ odoo_role_git_ref }}"
+
+  when:
+    - odoo_role_odoo_edition == "oca"
+    - odoo_installed_version.changed
+
+
+- name: Write down the version we just downloaded
+  copy:
+    content: "{{ odoo_role_odoo_release }}"
+    dest: "{{ odoo_role_odoo_version_file }}"
+    owner: "{{ odoo_role_odoo_user }}"
+    group: "{{ odoo_role_odoo_group }}"
+    mode: 0644
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,10 +91,16 @@
     state: link
   when: ansible_distribution == "Ubuntu" and not ansible_distribution_version == "18.04"
 
+- name: Get installed Odoo version (if any)
+  shell: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} --version | cut -d ' ' -f 3"
+  register: odoo_installed_version
+
 - name: Install Odoo
   become_user: "{{ odoo_role_odoo_user }}"
+  vars:
+    odoo_required_version: "{{ odoo_role_odoo_version }}-{{ odoo_role_odoo_release }}"
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
-  when: odoo_installed_version.changed
+  when: not odoo_installed_version.stdout == odoo_required_version
 
 - name: Add Odoo config
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,16 +91,10 @@
     state: link
   when: ansible_distribution == "Ubuntu" and not ansible_distribution_version == "18.04"
 
-- name: Get installed Odoo version (if any)
-  shell: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} --version | cut -d ' ' -f 3"
-  register: odoo_installed_version
-
 - name: Install Odoo
   become_user: "{{ odoo_role_odoo_user }}"
-  vars:
-    odoo_required_version: "{{ odoo_role_odoo_version }}-{{ odoo_role_odoo_release }}"
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
-  when: not odoo_installed_version.stdout == odoo_required_version
+  when: odoo_installed_version.changed
 
 - name: Add Odoo config
   become: yes


### PR DESCRIPTION
As stated in #46 , `odoo_role_odoo_head` is not honored, we are cloning to reference named by `odoo_role_odoo_version`.

This PR creates a new variable , `odoo_role_odoo_git_ref`, that suggests that both branches, commits, tags... can be used to clone the repo. See [ansible git module parameters](https://docs.ansible.com/ansible/latest/modules/git_module.html#parameters) for details.

This doesn't fully close #46, because using git refs to upstream OCB is dangerous as they squash commits.