### PR TITLE
Improve download strategies and add new edition

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,26 +6,20 @@ odoo_role_odoo_group: odoo
 # VirtualEnv vars
 odoo_role_odoo_venv_path: /opt/.odoo_venv
 
-odoo_role_odoo_edition: oca
-
 # Edition vars
-# Vars for the Odoo Nightly edition
-# odoo_role_odoo_edition: "odoo"
-odoo_role_odoo_version: 11.0
-odoo_role_odoo_release: 20170914
-odoo_role_odoo_url: "https://nightly.odoo.com/{{ odoo_role_odoo_version }}/nightly/src/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
-odoo_role_odoo_download_path: "/tmp/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
 
-# odoo_role_odoo_edition: coopdevs
-odoo_role_odoo_release: 11.0_2018-06-11
-odoo_role_odoo_url: "https://gitlab.com/coopdevs/OCB/-/archive/{{ odoo_role_odoo_release }}/OCB-{{ odoo_role_odoo_release }}.tar.gz"
-odoo_role_odoo_download_path: "/tmp/ocb-{{ odoo_role_odoo_release }}.tar.gz"
+# Vars for the Odoo Nightly edition
+odoo_role_download_strategy: tar
+odoo_role_odoo_version: 11.0
+odoo_role_odoo_release: 20190501
+odoo_role_odoo_url: "https://nightly.odoo.com/{{ odoo_role_odoo_version }}/nightly/src/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
+odoo_role_odoo_download_path: "{{ odoo_role_odoo_path }}/../odoo_releases/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
 
 # Vars for the OCA/OCB edition
-# odoo_role_odoo_edition: "oca"
+# odoo_role_download_strategy: git
 odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
-# OCA/OCB, branch 11.0, June 11 2018
-odoo_role_odoo_git_ref: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
+# OCA/OCB, branch 11.0, May 1 2019
+odoo_role_odoo_git_ref: "903fec011d64cd50a4e925d4046757afacf1363a"
 
 odoo_role_odoo_path: /opt/odoo
 odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/odoo-bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,8 +18,8 @@ odoo_role_odoo_download_path: "{{ odoo_role_odoo_path }}/../odoo_releases/odoo_{
 # Vars for the OCA/OCB edition
 # odoo_role_download_strategy: git
 odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
-# OCA/OCB, branch 11.0, May 1 2019
-odoo_role_odoo_git_ref: "903fec011d64cd50a4e925d4046757afacf1363a"
+# OCA/OCB, branch 11.0. LTS probably until 14.0 release. 13.0 is scheduled for October 2019.
+odoo_role_odoo_git_ref: "11.0"
 
 odoo_role_odoo_path: /opt/odoo
 odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/odoo-bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,17 +16,23 @@ odoo_role_odoo_release: 20170914
 odoo_role_odoo_url: "https://nightly.odoo.com/{{ odoo_role_odoo_version }}/nightly/src/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
 odoo_role_odoo_download_path: "/tmp/odoo_{{ odoo_role_odoo_version }}.{{ odoo_role_odoo_release }}.tar.gz"
 
+# odoo_role_odoo_edition: coopdevs
+odoo_role_odoo_release: 11.0_2018-06-11
+odoo_role_odoo_url: "https://gitlab.com/coopdevs/OCB/-/archive/{{ odoo_role_odoo_release }}/OCB-{{ odoo_role_odoo_release }}.tar.gz"
+odoo_role_odoo_download_path: "/tmp/ocb-{{ odoo_role_odoo_release }}.tar.gz"
+
 # Vars for the OCA/OCB edition
 # odoo_role_odoo_edition: "oca"
 odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
 # OCA/OCB, branch 11.0, June 11 2018
-odoo_role_git_ref: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
+odoo_role_odoo_git_ref: "8ef3986d58a097a04502d9ca1ee0a860d7230723"
 
 odoo_role_odoo_path: /opt/odoo
 odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/odoo-bin"
 odoo_role_odoo_python_path: "{{ odoo_role_odoo_venv_path }}/bin/python"
 odoo_role_odoo_config_path: /etc/odoo
 odoo_role_odoo_modules_path: /opt/odoo_modules
+odoo_role_odoo_version_file: "{{ odoo_role_odoo_path }}/.odoo_version.txt"
 
 odoo_role_odoo_log_path: /var/log/odoo
 odoo_role_odoo_log_level: debug
@@ -39,3 +45,4 @@ odoo_role_odoo_db_admin_password: iT0ohDuoth6ONgahDeepaich0aeka5ul
 odoo_role_odoo_core_modules: "base"
 
 odoo_daemon: "odoo.service"
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ odoo_role_odoo_venv_path: /opt/.odoo_venv
 
 # Edition vars
 
-# Vars for the Odoo Nightly edition
+# Vars for tar download strategy (or other formats supported by ansible unarchive, i.e. by unzip or gtar)
 odoo_role_download_strategy: tar
 odoo_role_odoo_version: 11.0
 odoo_role_odoo_release: 20190501

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,6 @@ odoo_role_odoo_bin_path: "{{ odoo_role_odoo_path }}/odoo-bin"
 odoo_role_odoo_python_path: "{{ odoo_role_odoo_venv_path }}/bin/python"
 odoo_role_odoo_config_path: /etc/odoo
 odoo_role_odoo_modules_path: /opt/odoo_modules
-odoo_role_odoo_version_file: "{{ odoo_role_odoo_path }}/.odoo_version.txt"
 
 odoo_role_odoo_log_path: /var/log/odoo
 odoo_role_odoo_log_level: debug

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -17,6 +17,18 @@
       group: "{{ odoo_role_odoo_group }}"
     register: odoo_role_desired_download
 
+  - name: Clean older release packets
+    vars:
+      dirname: {{ odoo_role_odoo_download_path  | dirname }}
+      basename: {{ odoo_role_odoo_download_path  | basename }}
+    # Find under download path dir, all elements of type file, such that
+    # they don't have a name that it's the one of the file we just downloaded.
+    # For each match, delete it and print it's path, so that
+    # we can tell from the output wether anything got found-deleted or not.
+    command: "find "{{ dir }}" -type f -not -name '{{ basename }}' -delete -print"
+    register: find
+    changed_when: find.stdout != ""
+
   - name: Uncompress downloaded Odoo
     unarchive:
       src: "{{ odoo_role_odoo_download_path }}"

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -19,8 +19,8 @@
 
   - name: Clean older release packets
     vars:
-      dirname: {{ odoo_role_odoo_download_path  | dirname }}
-      basename: {{ odoo_role_odoo_download_path  | basename }}
+      dirname: {{ odoo_role_odoo_download_path | dirname }}
+      basename: {{ odoo_role_odoo_download_path | basename }}
     # Find under download path dir, all elements of type file, such that
     # they don't have a name that it's the one of the file we just downloaded.
     # For each match, delete it and print it's path, so that

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,22 +1,21 @@
 ---
-
-- name: Search hint to find out which Odoo version is installed
-  command: "cat {{ odoo_role_odoo_version_file }}"
-  register: odoo_installed_version
-  changed_when:
-    - odoo_installed_version.stdout != odoo_role_odoo_release
-    - odoo_installed_version.stdout != odoo_role_odoo_git_ref
-  failed_when: false
-
 # Odoo from the Odoo Nightly: http://nightly.odoo.com/
 - name: Download an Odoo release tar packet
   block:
+  - name: Ensure download path exists
+    file:
+      path: "{{ odoo_role_odoo_download_path  | dirname }}"
+      state: directory
+      owner: "{{ odoo_role_odoo_user }}"
+      group: "{{ odoo_role_odoo_group }}"
+
   - name: Download Odoo
     get_url:
       url: "{{ odoo_role_odoo_url }}"
       dest: "{{ odoo_role_odoo_download_path }}"
       owner: "{{ odoo_role_odoo_user }}"
       group: "{{ odoo_role_odoo_group }}"
+    register: odoo_role_desired_download
 
   - name: Uncompress downloaded Odoo
     unarchive:
@@ -26,36 +25,20 @@
       owner: "{{ odoo_role_odoo_user }}"
       group: "{{ odoo_role_odoo_group }}"
       extra_opts: [--strip-components=1]
+    when: odoo_role_desired_download.changed
 
-  - set_fact: odoo_role_downloaded_version = "{{ odoo_role_odoo_release }}"
-
-  when:
-    - odoo_role_odoo_edition  == "odoo" or odoo_role_odoo_edition == "coopdevs"
-    - odoo_installed_version.changed
+  when: odoo_role_download_strategy == "tar"
 
 
 # Odoo from the OCA/OCB repository: https://github.com/OCA/OCB
-- block:
-  - name: "Git clone git reference {{ odoo_role_odoo_git_ref }}"
-    become_user: "{{ odoo_role_odoo_user }}"
-    git:
-      repo: "{{ odoo_role_odoo_git_url }}"
-      dest: "{{ odoo_role_odoo_path }}"
-      version: "{{ odoo_role_odoo_git_ref }}"
-      depth: 1
+- name: "Git clone git reference {{ odoo_role_odoo_git_ref }}"
+  become_user: "{{ odoo_role_odoo_user }}"
+  git:
+    repo: "{{ odoo_role_odoo_git_url }}"
+    dest: "{{ odoo_role_odoo_path }}"
+    version: "{{ odoo_role_odoo_git_ref }}"
+    depth: 1
+    force: yes
 
-  - set_fact: odoo_role_downloaded_version = "{{ odoo_role_git_ref }}"
-
-  when:
-    - odoo_role_odoo_edition == "oca"
-    - odoo_installed_version.changed
-
-
-- name: Write down the version we just downloaded
-  copy:
-    content: "{{ odoo_role_odoo_release }}"
-    dest: "{{ odoo_role_odoo_version_file }}"
-    owner: "{{ odoo_role_odoo_user }}"
-    group: "{{ odoo_role_odoo_group }}"
-    mode: 0644
+  when: odoo_role_download_strategy == "git"
 

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -51,6 +51,6 @@
     version: "{{ odoo_role_odoo_git_ref }}"
     depth: 1
     force: yes
-
+  register: odoo_role_desired_download
   when: odoo_role_download_strategy == "git"
 

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -4,7 +4,7 @@
   block:
   - name: Ensure download path exists
     file:
-      path: "{{ odoo_role_odoo_download_path  | dirname }}"
+      path: "{{ odoo_role_odoo_download_path | dirname }}"
       state: directory
       owner: "{{ odoo_role_odoo_user }}"
       group: "{{ odoo_role_odoo_group }}"
@@ -19,13 +19,13 @@
 
   - name: Clean older release packets
     vars:
-      dirname: {{ odoo_role_odoo_download_path | dirname }}
-      basename: {{ odoo_role_odoo_download_path | basename }}
+      dirname: "{{ odoo_role_odoo_download_path | dirname }}"
+      basename: "{{ odoo_role_odoo_download_path | basename }}"
     # Find under download path dir, all elements of type file, such that
     # they don't have a name that it's the one of the file we just downloaded.
     # For each match, delete it and print it's path, so that
     # we can tell from the output wether anything got found-deleted or not.
-    command: "find "{{ dir }}" -type f -not -name '{{ basename }}' -delete -print"
+    command: "find {{ dirname }} -type f -not -name '{{ basename }}' -delete -print"
     register: find
     changed_when: find.stdout != ""
 

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,5 +1,5 @@
 ---
-# Odoo from the Odoo Nightly: http://nightly.odoo.com/
+# Odoo release packed in a compressed file supported by gtar or unzip
 - name: Download an Odoo release tar packet
   block:
   - name: Ensure download path exists

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,30 +1,61 @@
 ---
-# Odoo from the Odoo Nightly: http://nightly.odoo.com/
-- name: Download Odoo
-  get_url:
-    url: "{{ odoo_role_odoo_url }}"
-    dest: "{{ odoo_role_odoo_download_path }}"
-    owner: "{{ odoo_role_odoo_user }}"
-    group: "{{ odoo_role_odoo_group }}"
-  when: odoo_role_odoo_edition == "odoo"
 
-- name: Uncompress downloaded Odoo
-  unarchive:
-    src: "{{ odoo_role_odoo_download_path }}"
-    dest: "{{ odoo_role_odoo_path }}"
-    remote_src: yes
-    owner: "{{ odoo_role_odoo_user }}"
-    group: "{{ odoo_role_odoo_group }}"
-    extra_opts: [--strip-components=1]
-    creates: "{{ odoo_role_odoo_path }}/setup.py"
-  when: odoo_role_odoo_edition  == "odoo"
+- name: Search hint to find out which Odoo version is installed
+  command: "cat {{ odoo_role_odoo_version_file }}"
+  register: odoo_installed_version
+  changed_when:
+    - odoo_installed_version.stdout != odoo_role_odoo_release
+    - odoo_installed_version.stdout != odoo_role_odoo_git_ref
+  failed_when: false
+
+# Odoo from the Odoo Nightly: http://nightly.odoo.com/
+- name: Download an Odoo release tar packet
+  block:
+  - name: Download Odoo
+    get_url:
+      url: "{{ odoo_role_odoo_url }}"
+      dest: "{{ odoo_role_odoo_download_path }}"
+      owner: "{{ odoo_role_odoo_user }}"
+      group: "{{ odoo_role_odoo_group }}"
+
+  - name: Uncompress downloaded Odoo
+    unarchive:
+      src: "{{ odoo_role_odoo_download_path }}"
+      dest: "{{ odoo_role_odoo_path }}"
+      remote_src: yes
+      owner: "{{ odoo_role_odoo_user }}"
+      group: "{{ odoo_role_odoo_group }}"
+      extra_opts: [--strip-components=1]
+
+  - set_fact: odoo_role_downloaded_version = "{{ odoo_role_odoo_release }}"
+
+  when:
+    - odoo_role_odoo_edition  == "odoo" or odoo_role_odoo_edition == "coopdevs"
+    - odoo_installed_version.changed
+
 
 # Odoo from the OCA/OCB repository: https://github.com/OCA/OCB
-- name: "Git clone git reference {{ odoo_role_odoo_git_ref }}"
-  become_user: "{{ odoo_role_odoo_user }}"
-  git:
-    repo: "{{ odoo_role_odoo_git_url }}"
-    dest: "{{ odoo_role_odoo_path }}"
-    version: "{{ odoo_role_odoo_git_ref }}"
-    depth: 1
-  when: odoo_role_odoo_edition == "oca"
+- block:
+  - name: "Git clone git reference {{ odoo_role_odoo_git_ref }}"
+    become_user: "{{ odoo_role_odoo_user }}"
+    git:
+      repo: "{{ odoo_role_odoo_git_url }}"
+      dest: "{{ odoo_role_odoo_path }}"
+      version: "{{ odoo_role_odoo_git_ref }}"
+      depth: 1
+
+  - set_fact: odoo_role_downloaded_version = "{{ odoo_role_git_ref }}"
+
+  when:
+    - odoo_role_odoo_edition == "oca"
+    - odoo_installed_version.changed
+
+
+- name: Write down the version we just downloaded
+  copy:
+    content: "{{ odoo_role_odoo_release }}"
+    dest: "{{ odoo_role_odoo_version_file }}"
+    owner: "{{ odoo_role_odoo_user }}"
+    group: "{{ odoo_role_odoo_group }}"
+    mode: 0644
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,16 +91,10 @@
     state: link
   when: ansible_distribution == "Ubuntu" and not ansible_distribution_version == "18.04"
 
-- name: Get installed Odoo version (if any)
-  shell: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} --version | cut -d ' ' -f 3"
-  register: odoo_installed_version
-
 - name: Install Odoo
   become_user: "{{ odoo_role_odoo_user }}"
-  vars:
-    odoo_required_version: "{{ odoo_role_odoo_version }}-{{ odoo_role_odoo_release }}"
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
-  when: not odoo_installed_version.stdout == odoo_required_version
+  when: odoo_installed_version.changed
 
 - name: Add Odoo config
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,7 @@
 - name: Install Odoo
   become_user: "{{ odoo_role_odoo_user }}"
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
-  when: odoo_installed_version.changed
+  when: odoo_role_desired_download.changed
 
 - name: Add Odoo config
   become: yes


### PR DESCRIPTION
Comes from issue #46 
First I pushed the changes to #47 but it was an overload.
Closes issue #48 , which I opened from a comment in #47 

* New edition: releases we do from gitlab.com mirror of OCB. This is a tar.gz
as odoo edition download strategy.
* Adapt defaults to reflect the new download strategy
* Create a new version file that will be kept at remote. This is used to be
able to know which release was deployed both by git or by extracting the
package. In this second case, it's more important as there's no way to recover
that information.
* Use this version file to create guards. Only download and install if the
desired version (from variables) is different from the existing one
(from the version hidden file)