### PR TITLE
Redirect odoobin output

### DIFF
--- a/tasks/community-modules.yml
+++ b/tasks/community-modules.yml
@@ -14,10 +14,10 @@
 - name: Update Odoo modules list
   become: yes
   become_user: "{{ odoo_role_odoo_user }}"
-  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --update all --stop-after-init --without-demo=all"
+  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --update all --stop-after-init --without-demo=all --logfile=/dev/stdout --log-level=warn"
 
 - name: Install community Odoo roles
   become: yes
   become_user: "{{ odoo_role_odoo_user }}"
-  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_community_odoo_modules }} --stop-after-init --without-demo=all"
+  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_community_odoo_modules }} --stop-after-init --without-demo=all --logfile=/dev/stdout --log-level=warn"
   notify: restart odoo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,7 +109,7 @@
 - name: Init Odoo database
   become: yes
   become_user: "{{ odoo_role_odoo_user }}"
-  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_odoo_core_modules }} --stop-after-init --without-demo=all --logfile=/dev/stdout --log-level=warn"
+  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_odoo_core_modules }} --stop-after-init --without-demo=all"
   notify: restart odoo
 
 - import_tasks: community-modules.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,7 +109,7 @@
 - name: Init Odoo database
   become: yes
   become_user: "{{ odoo_role_odoo_user }}"
-  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_odoo_core_modules }} --stop-after-init --without-demo=all"
+  command: "{{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf -d {{ odoo_role_odoo_db_name }} --init {{ odoo_role_odoo_core_modules }} --stop-after-init --without-demo=all --logfile=/dev/stdout --log-level=warn"
   notify: restart odoo
 
 - import_tasks: community-modules.yml


### PR DESCRIPTION
Right now, if the command fails, Ansible gets nothing in output terms (neither err), and this is bad to debug. We need to go find the log inside the host at /etc/odoo/odoo.log, but this is mixed with other log entries. A perfect approach would feed both stdout and default log

For instance, if for some reason  update odoo modules fails, we get:
```
fatal: [odoo.coopdevs.org]: FAILED! => 
{
   "start" : "2019-05-17 11:45:13.626822",
   "delta" : "0:01:04.866362",
   "stdout" : "",
   "stdout_lines" : [],
   "changed" : true,
   "msg" : "non-zero return code",
   "cmd" : [
      "/opt/.odoo_venv/bin/python",
      "/opt/odoo/odoo-bin",
      "-c",
      "/etc/odoo/odoo.conf",
      "-d",
      "odoo",
      "--update",
      "all",
      "--stop-after-init",
      "--without-demo=all"
   ],
   "end" : "2019-05-17 11:46:18.493184",
   "stderr" : "",
   "rc" : 255,
   "stderr_lines" : []
}
```

So we get nothing else useful than the exact command and time executed, and the error code (rc).

With the modifications I propose, stdout / stderr will contain warning and error messages. 