### PR TITLE
Create an option to switch demo-data on or off

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ odoo_role_odoo_modules_path: /opt/odoo/modules
 odoo_role_odoo_db_name: odoo
 # This not a DB user password, but a password for Odoo to deal with DB.
 odoo_role_odoo_db_admin_password: 1234
+# Whether to populate db with example data or not.
+odoo_role_demo_data: false
 ```
 
 * Core modules list to install/update

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,3 +39,5 @@ odoo_role_odoo_core_modules: "base"
 
 odoo_daemon: "odoo.service"
 
+# Whether to populate db with example data or not.
+odoo_role_demo_data: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -126,7 +126,7 @@
     --init base
     --stop-after-init
     {% if not odoo_role_demo_data %}
-    --without-demo-data=all
+    --without-demo=all
     {% endif %}
     --logfile=/dev/stdout
     --log-level=warn
@@ -161,7 +161,7 @@
     --init {{ modules_to_install.stdout_lines | join(',') }}
     --stop-after-init
     {% if not odoo_role_demo_data %}
-    --without-demo-data=all
+    --without-demo=all
     {% endif %}
     --logfile=/dev/stdout
     --log-level=warn

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,7 +125,9 @@
     -d {{ odoo_role_odoo_db_name }}
     --init base
     --stop-after-init
-    --without-demo=all
+    {% if not odoo_role_demo_data %}
+    --without-demo-data=all
+    {% endif %}
     --logfile=/dev/stdout
     --log-level=warn
   when: db_initialized.stdout == "0"
@@ -158,7 +160,9 @@
     -d {{ odoo_role_odoo_db_name }}
     --init {{ modules_to_install.stdout_lines | join(',') }}
     --stop-after-init
-    --without-demo=all
+    {% if not odoo_role_demo_data %}
+    --without-demo-data=all
+    {% endif %}
     --logfile=/dev/stdout
     --log-level=warn
   when: modules_to_install.stdout


### PR DESCRIPTION
It is `odoo_role_demo_data: false` by default,
but can be overriden as other vars, also from the cli like this:

    ansible-playbook -i "inventory" \
    --limit=some-host my_playbook \
    --extra-vars="odoo_role_demo_data=true"

---

This is useful for testing or showcasing instances.