### PR TITLE
Allow custom Odoo HTTP server binding interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ odoo_role_odoo_db_admin_password: 1234
 odoo_role_demo_data: false
 ```
 
+* Odoo HTTP server settings
+
+```
+# Set this to 127.0.0.1 when Odoo runs behind a reverse proxy
+odoo_role_odoo_http_interface: 0.0.0.0
+# Set this to true when Odoo runs behind a reverse proxy
+odoo_role_odoo_proxy_mode: false
+```
+
 * Core modules list to install/update
 
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,7 @@ odoo_daemon: "odoo.service"
 
 # Whether to populate db with example data or not.
 odoo_role_demo_data: false
+
+# HTTP server settings
+odoo_role_odoo_http_interface: "0.0.0.0"
+odoo_role_odoo_proxy_mode: false

--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -8,3 +8,7 @@ addons_path = {{ odoo_role_odoo_path }}/addons,{{ odoo_role_odoo_modules_path }}
 
 ; Master password to manage dbs
 admin_passwd = {{ odoo_role_odoo_db_admin_password }}
+
+; HTTP server settings
+http_interface = {{ odoo_role_odoo_http_interface }}
+proxy_mode = {{ odoo_role_odoo_proxy_mode }}


### PR DESCRIPTION
Running Odoo behind a reverse proxy we need to bind its HTTP server to `127.0.0.1`. The default is `0.0.0.0`.

Please refer to https://www.odoo.com/documentation/11.0/reference/cmdline.html for further details.

Keep in mind the we'll generally set these variables at host level in `/host_vars/HOST/config.yml`.

Fix #57 