### PR TITLE
Please the desires of ansible-galaxy linters...

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+# Skip some picky ansible lint warnings
+skip_list:
+  - '503' # Tasks that run when changed should likely be handlers
+  - '602' # Don’t compare to empty string

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
 script:
   # Check the role/playbook's syntax.
   - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
+  - ansible-lint .
 
 webhooks: https://galaxy.ansible.com/api/v1/notifications/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   # Check the role/playbook's syntax.
   - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
   - ansible-lint .
-  - yamllint .
+  - yamllint -c .yamllint.yaml .
 
 webhooks: https://galaxy.ansible.com/api/v1/notifications/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ before_install:
   - sudo apt-get update -qq
 
 install:
-  # Install Ansible.
+  # Install Ansible and linters
   - pip install ansible
+  - pip install ansible-lint
+  - sudo apt-get install yamllint
 
   # Add ansible.cfg to pick up roles path.
   - printf '[defaults]\nroles_path=../' >ansible.cfg
@@ -17,6 +19,7 @@ script:
   # Check the role/playbook's syntax.
   - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
   - ansible-lint .
+  - yamllint .
 
 webhooks: https://galaxy.ansible.com/api/v1/notifications/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 dist: xenial
 language: python
-python: "2.7"
+python: "3.7"
 
 before_install:
   # Make sure everything's up to date.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+dist: xenial
 language: python
 python: "2.7"
 

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,21 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces: {max-spaces-inside: 1, level: error}
+  brackets: {max-spaces-inside: 1, level: error}
+  colons: {max-spaces-after: -1, level: error}
+  commas: {max-spaces-after: -1, level: error}
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines: {max: 3, level: error}
+  hyphens: {level: error}
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: {type: unix}
+  trailing-spaces: disable
+  truthy: disable

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -18,4 +18,4 @@ rules:
   new-line-at-end-of-file: disable
   new-lines: {type: unix}
   trailing-spaces: disable
-  truthy: disable
+#  truthy: disable

--- a/tasks/community-modules.yml
+++ b/tasks/community-modules.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copy requirements.txt
-  copy:
-    src: "{{ inventory_dir }}/../files/requirements.txt"
+  copy: # 'noqa' below disables [E404] Don’t compare to empty string
+    src: "{{ inventory_dir }}/../files/requirements.txt" # noqa 404
     dest: "{{ odoo_role_odoo_modules_path }}/requirements.txt"
     owner: "{{ odoo_role_odoo_user }}"
     group: "{{ odoo_role_odoo_group }}"

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -55,6 +55,7 @@
 
 # Odoo from the OCA/OCB repository: https://github.com/OCA/OCB
 - name: "Git clone git reference {{ odoo_role_odoo_git_ref }}"
+  become: yes
   become_user: "{{ odoo_role_odoo_user }}"
   git:
     repo: "{{ odoo_role_odoo_git_url }}"
@@ -64,4 +65,3 @@
     force: yes
   register: odoo_role_desired_git_download
   when: odoo_role_download_strategy == "git"
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,9 @@
     state: present
 
 - name: Check if wkhtmltopdf is installed
-  shell: dpkg -s wkhtmltox | grep 'install ok installed'
+  shell: set -o pipefail && dpkg -s wkhtmltox | grep 'install ok installed'
+  args:
+    executable: /bin/bash
   register: wkhtmltox_installed
   failed_when: false
   changed_when: no
@@ -92,6 +94,7 @@
   when: ansible_distribution == "Ubuntu" and not ansible_distribution_version == "18.04"
 
 - name: Install Odoo
+  become: yes
   become_user: "{{ odoo_role_odoo_user }}"
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
   when: odoo_role_desired_tar_download.changed or odoo_role_desired_git_download.changed
@@ -116,6 +119,7 @@
     WHERE table_name='ir_module_module';"
   register: db_initialized
   with_items: "{{ odoo_role_odoo_dbs }}"
+  changed_when: false
 
 - name: "Init Odoo database(s): odoo_role_odoo_dbs"
   become: yes
@@ -155,6 +159,7 @@
   vars:
     - separator: "'), ('"
   with_items: "{{ odoo_role_odoo_dbs }}"
+  changed_when: false
 
 - name: Install only new Odoo modules
   become: yes


### PR DESCRIPTION
or explicitly ignore them with .ansible-lint file and noqa inline comment

Addresses the errors and warnings from ansible-galaxy:
```
Starting import: task_id=455623, repository=coopdevs/odoo-role 
 
===== LOADING ROLE ===== 
Checking role metadata tags 
Checking role platforms 
Checking role cloud platforms 
Checking role dependencies 
 
===== LINTING ROLE ===== 
yamllint Warnings: 
./tasks/download.yml:67:1: [error] too many blank lines (1 > 0) (empty-lines) 
ansible-lint Warnings: 
./galaxy/imports/tmpehvruf8c/tasks/community-modules.yml:2: [E404] Doesn't need a relative path in role 
./galaxy/imports/tmpehvruf8c/tasks/download.yml:30: [E602] Don't compare to empty string 
./galaxy/imports/tmpehvruf8c/tasks/download.yml:57: [E501] become_user requires become to work as expected 
./galaxy/imports/tmpehvruf8c/tasks/main.yml:21: [E306] Shells that use pipes should set the pipefail option 
./galaxy/imports/tmpehvruf8c/tasks/main.yml:94: [E501] become_user requires become to work as expected 
./galaxy/imports/tmpehvruf8c/tasks/main.yml:94: [E503] Tasks that run when changed should likely be handlers 
./galaxy/imports/tmpehvruf8c/tasks/main.yml:109: [E301] Commands should not change things if nothing needs doing 
./galaxy/imports/tmpehvruf8c/tasks/main.yml:142: [E301] Commands should not change things if nothing needs doing 
 
===== IMPORTING ROLE: odoo-role ===== 
 
Updating repository versions... 
Import completed with 9 warnings and 0 errors 
```