### PR TITLE
Set dbfilter to use full domain instead of subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ odoo_role_odoo_modules_path: /opt/odoo/modules
 ```yml
 # Array of DBs that the role will create.
 odoo_role_odoo_dbs: [ "odoo" ]
+# In a multidb environment, where more than one group use the same instance with isolated views,
+# each db name must match the DNS name it will accessed from in order for Odoo to direct the queries to the right DB.
+odoo_role_odoo_dbs: [ "odoo.some.coop", "erp.another.org" ]
 # This is the password Odoo asks to user allow them to create, delete, etc. DBs
 odoo_role_odoo_db_admin_password: 1234
 # Whether to populate db with example data or not.

--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ odoo_role_odoo_dbs: [ "odoo" ]
 # In a multidb environment, where more than one group use the same instance with isolated views,
 # each db name must match the DNS name it will accessed from in order for Odoo to direct the queries to the right DB.
 odoo_role_odoo_dbs: [ "odoo.some.coop", "erp.another.org" ]
+# Only in multidb environment, select DB based on the HTTP Host header.
+odoo_role_dbfilter_enabled: true
 # This is the password Odoo asks to user allow them to create, delete, etc. DBs
 odoo_role_odoo_db_admin_password: 1234
 # Whether to populate db with example data or not.
 odoo_role_demo_data: false
-# Wether or not to give the chance to select another existing database that has not been filtered by dbfilter
-odoo_role_show_db_list: false
+# Give the chance to select a database before login (when dbfilter disabled), and enable db manager web interface
+odoo_role_list_db: false
 ```
 
 * Odoo HTTP server settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,8 +39,13 @@ odoo_role_odoo_db_name: odoo
 odoo_role_odoo_dbs: [ "{{ odoo_role_odoo_db_name }}" ]
 # This not a DB user password, but a password for Odoo to deal with DB.
 odoo_role_odoo_db_admin_password: iT0ohDuoth6ONgahDeepaich0aeka5ul
-# Wether or not to give the chance to select another existing database that has not been filtered by dbfilter
-odoo_role_show_db_list: False
+# Give the chance to select a database before login not filtered out by dbfilter, and enable db manager web interface.
+# In multi db mode, this is only relevant to db manager, as we force list_db to avoid an unaccessible website when dbfilter is disabled.
+# In single db mode,we disable dbfilter and respect list_db.
+odoo_role_list_db: False
+# Security option that disables the web-base database manager and filters available DBs to list before login.
+# We ignore this setting in single DB mode to allow simpler db names such as "odoo" instead of domain name.
+odoo_role_dbfilter_enabled: True
 
 # Comma-separated list of modules to install before running the server
 odoo_role_odoo_core_modules: "base"

--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -13,11 +13,14 @@ admin_passwd = {{ odoo_role_odoo_db_admin_password }}
 http_interface = {{ odoo_role_odoo_http_interface | default('0.0.0.0') }}
 proxy_mode = {{ odoo_role_odoo_proxy_mode | default(false) }}
 
-{% if ( odoo_role_odoo_dbs | count ) > 1 %}
+{% if ( odoo_role_odoo_dbs | count ) > 1 and odoo_role_dbfilter_enabled %}
 ; Before login, use only the database that matches full domain of Host header
 dbfilter = ^%h$
 {% endif %}
-{% if odoo_role_show_db_list == False %}
-; Give the chance to select another (not filtered by dbfilter) existing database
-list_db = False
+; Allow to select another (not filtered by dbfilter) existing database and enable db manager
+{# Avoid situation where odoo doesn't know what to show (dbfilter) nor can ask to (list_db) #}
+{% if ( odoo_role_odoo_dbs | count ) > 1 and not odoo_role_dbfilter_enabled %}
+list_db = True
+{% else %}
+list_db = {{ odoo_role_list_db }}
 {% endif %}

--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -14,8 +14,8 @@ http_interface = {{ odoo_role_odoo_http_interface | default('0.0.0.0') }}
 proxy_mode = {{ odoo_role_odoo_proxy_mode | default(false) }}
 
 {% if ( odoo_role_odoo_dbs | count ) > 1 %}
-; Before login, use only the database that matches subdomain of Host header
-dbfilter = ^%d$
+; Before login, use only the database that matches full domain of Host header
+dbfilter = ^%h$
 {% endif %}
 {% if odoo_role_show_db_list == False %}
 ; Give the chance to select another (not filtered by dbfilter) existing database


### PR DESCRIPTION
We want to be able to have a multidb env with different domain names, and the current setting only allows for names of the same parent domain. Otherwise collisions would happen between odoo.example.org and odoo.eggssample.org.