### PR TITLE
Default to proxied env.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,5 +51,5 @@ odoo_daemon: "odoo.service"
 odoo_role_demo_data: false
 
 # HTTP server settings
-odoo_role_odoo_http_interface: "127.0.1.1"
+odoo_role_odoo_http_interface: "127.0.0.1"
 odoo_role_odoo_proxy_mode: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,5 +51,5 @@ odoo_daemon: "odoo.service"
 odoo_role_demo_data: false
 
 # HTTP server settings
-odoo_role_odoo_http_interface: "0.0.0.0"
-odoo_role_odoo_proxy_mode: false
+odoo_role_odoo_http_interface: "127.0.1.1"
+odoo_role_odoo_proxy_mode: true

--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -10,8 +10,8 @@ addons_path = {{ odoo_role_odoo_path }}/addons,{{ odoo_role_odoo_modules_path }}
 admin_passwd = {{ odoo_role_odoo_db_admin_password }}
 
 ; HTTP server settings
-http_interface = {{ odoo_role_odoo_http_interface | default('0.0.0.0') }}
-proxy_mode = {{ odoo_role_odoo_proxy_mode | default(false) }}
+http_interface = {{ odoo_role_odoo_http_interface }}
+proxy_mode = {{ odoo_role_odoo_proxy_mode }}
 
 {% if ( odoo_role_odoo_dbs | count ) > 1 %}
 ; Before login, use only the database that matches subdomain of Host header


### PR DESCRIPTION
This means only listen to addresses at loopback if, and enable the odoo flag to enable proxied mode (modifies certain http headers)

From #67

Also remove `default` filter to a couple of vas, as defaults/all.yml is already defined at `default/main.yml`