### PR TITLE
Fix regexp that detects new/upgraded pkgs form pip

### DIFF
--- a/tasks/community-modules.yml
+++ b/tasks/community-modules.yml
@@ -14,17 +14,31 @@
   become: yes
   become_user: "{{ odoo_role_odoo_user }}"
 
+  # Using the output of pip, detect which packages have been installed,
+  # both fresh or upgraded. Save the list with a register so that we can
+  # feed better odoo with it.
 - name: Detect upgraded packages
+  args:
+    # Example input (delete '# ' from each line below)
+    #
+    # Installing collected packages: odoo11-addon-account-financial-report
+    # Found existing installation: odoo11-addon-account-financial-report 11.0.2.4.3
+    # Uninstalling odoo11-addon-account-financial-report-11.0.2.4.3:
+    #  Successfully uninstalled odoo11-addon-account-financial-report-11.0.2.4.3
+    # Successfully installed odoo11-addon-account-financial-report-11.0.2.5.1.99.dev12 odoo11-addon-l10n-es-aeat-mod303-11.0.2.1.0
+    stdin: "{{ reg_pip.stdout }}"
+    executable: bash
+  # Expected "output" using input from above (delete '# ' from each line below)
+  # note: "output" means `reg_pip_upgraded.stdout`
+  # note: to debug the second regexp you can use https://regexr.com/4l2c3
+  #
+  # account-financial-report
+  # l10n-es-aeat-mod303
   shell: >
     grep 'Successfully installed' |
     sed -r 's/ /\n/g' |
-    egrep '^odoo1[0-9]-addon-[^ ]+-[0-9\.]+' |
-    sed -r 's/odoo1[0-9]-addon-([^ ]+)-[0-9\.]+/\1/g' |
-    tr -- '-' '_'
-
-  args:
-    stdin: "{{ reg_pip.stdout }}"
-    executable: bash
+    sed -rn 's/^odoo(1[0-9])-addon-(.+)-\1\..+$/\2/p' |
+    tr '-' '_'
   register: reg_pip_upgraded
   changed_when: reg_pip_upgraded.stdout
   failed_when: false # noqa 306 "shell and pipefail". Both grep and sed must be able to fail

--- a/tasks/community-modules.yml
+++ b/tasks/community-modules.yml
@@ -34,6 +34,11 @@
   #
   # account-financial-report
   # l10n-es-aeat-mod303
+
+  # About sed:
+  # - option `-r` switches to standard perl regexp, instead of GNU ones. Similar to `egrep` or `grep -E`
+  # - option `-n` combined with flag `/p` prints "nothing" except the result of the script. Therefore, unmatching lines are hidden, and matching lines are shown after processed.
+  # - capturing groups `(something)` can be referenced inside the matching part or at the replacing part with \1, \2, in order of appearence. 
   shell: >
     grep 'Successfully installed' |
     sed -r 's/ /\n/g' |


### PR DESCRIPTION
* It doesn't assume that versions are numbers only. See for instance:
    https://pypi.org/project/odoo11-addon-l10n-es-mis-report/11.0.2.2.0.99.dev4/
* It uses the Odoo version number (supports from 10 to 19) as a
    delimiter between odoo module name and version
* Add infinite% more of explanation about the expected input and output

----

Tested with changes from MR https://gitlab.com/coopdevs/odoo-ecos-inventory/merge_requests/5
19 upgrades plus 1 new requirement that is not a module (openupgradelib)

**output**
```
    "stdout_lines": [
        "account_banking_mandate",
        "account_banking_pain_base",
        "account_banking_sepa_direct_debit",
        "account_financial_report",
        "account_payment_order",
        "account_payment_partner",
        "base_technical_features",
        "contract",
        "contract_sale_invoicing",
        "contract_variable_quantity",
        "l10n_es_account_bank_statement_import_n43",
        "l10n_es_account_invoice_sequence",
        "l10n_es_aeat",
        "l10n_es_aeat_mod303",
        "l10n_es_aeat_mod349",
        "l10n_es_mis_report",
        "l10n_es_partner",
        "mis_builder",
        "web_responsive"
    ]
```

**input**

```
Requirement already satisfied: openupgradelib from git+https://github.com/OCA/openupgradelib.git@master#egg=openupgradelib in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 2))
Collecting odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4 (from -r /opt/odoo_modules/requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/94/57/66de0433dde4aaa016ac2c36b35e5e9fa35eb467d11d2102f980b21e57c2/odoo11_addon_account_banking_mandate-11.0.2.0.0.99.dev4-py2.py3-none-any.whl
Collecting odoo11-addon-account-banking-pain-base==11.0.1.0.1 (from -r /opt/odoo_modules/requirements.txt (line 4))
  Using cached https://files.pythonhosted.org/packages/6a/0e/b3413d841c4d6811407ce2995b8277056eb89fccd3c2c85cb4eefd7aa956/odoo11_addon_account_banking_pain_base-11.0.1.0.1-py2.py3-none-any.whl
Requirement already satisfied: odoo11-addon-account-banking-sepa-credit-transfer==11.0.1.0.0 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 5))
Collecting odoo11-addon-account-banking-sepa-direct-debit==11.0.1.0.3 (from -r /opt/odoo_modules/requirements.txt (line 6))
  Using cached https://files.pythonhosted.org/packages/36/49/3114f015c104ca299361c19f1d2e608c475bf4cc38a4b951a0f200f7f1d4/odoo11_addon_account_banking_sepa_direct_debit-11.0.1.0.3-py2.py3-none-any.whl
Requirement already satisfied: odoo11-addon-account-due-list==11.0.2.0.0 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 7))
Collecting odoo11-addon-account-financial-report==11.0.2.4.3 (from -r /opt/odoo_modules/requirements.txt (line 8))
  Using cached https://files.pythonhosted.org/packages/d8/58/c39410a9a3d64c4889c2673397e024dc4c7b536a6f30b767269e9b9d7451/odoo11_addon_account_financial_report-11.0.2.4.3-py2.py3-none-any.whl
Requirement already satisfied: odoo11-addon-account-payment-mode==11.0.1.0.1 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 9))
Collecting odoo11-addon-account-payment-order==11.0.1.3.3 (from -r /opt/odoo_modules/requirements.txt (line 10))
  Using cached https://files.pythonhosted.org/packages/3b/f0/3614d77696f8fd1972e73c5840b6041795ed44c2b65d77b2237498fb2d6a/odoo11_addon_account_payment_order-11.0.1.3.3-py2.py3-none-any.whl
Collecting odoo11-addon-account-payment-partner==11.0.1.3.0.99.dev12 (from -r /opt/odoo_modules/requirements.txt (line 11))
  Using cached https://files.pythonhosted.org/packages/63/aa/68ba327efaf872af722436424eeaf8464f1fe28abaaf1486ca5cd5a83ccc/odoo11_addon_account_payment_partner-11.0.1.3.0.99.dev12-py2.py3-none-any.whl
Requirement already satisfied: odoo11-addon-base-bank-from-iban==11.0.1.0.0 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 12))
Collecting odoo11-addon-base-technical-features==11.0.1.0.0.99.dev7 (from -r /opt/odoo_modules/requirements.txt (line 13))
  Using cached https://files.pythonhosted.org/packages/65/b3/2eb5109f53e0a6e726d9546a9ba1d66ee5e20797dbd6270e08260fb22ca7/odoo11_addon_base_technical_features-11.0.1.0.0.99.dev7-py2.py3-none-any.whl
Collecting odoo11-addon-contract==11.0.4.1.0.99.dev4 (from -r /opt/odoo_modules/requirements.txt (line 14))
  Using cached https://files.pythonhosted.org/packages/26/af/d08260179271d78f10a251f00bf5412597a071cc768a4e1fa2b14339322e/odoo11_addon_contract-11.0.4.1.0.99.dev4-py2.py3-none-any.whl
Collecting odoo11-addon-contract-sale-invoicing==11.0.1.0.0.99.dev8 (from -r /opt/odoo_modules/requirements.txt (line 15))
  Using cached https://files.pythonhosted.org/packages/03/61/bcd4490cdcedfeccb849aa95893120568bcc0ef7e5c193fc9965501310f9/odoo11_addon_contract_sale_invoicing-11.0.1.0.0.99.dev8-py2.py3-none-any.whl
Collecting odoo11-addon-contract-variable-quantity==11.0.1.3.0.99.dev6 (from -r /opt/odoo_modules/requirements.txt (line 16))
  Using cached https://files.pythonhosted.org/packages/c3/b7/eff4d3444638b7cd63db0c4e1e440bbb56e7ec42043258703e2a5e5d9ff8/odoo11_addon_contract_variable_quantity-11.0.1.3.0.99.dev6-py2.py3-none-any.whl
Requirement already satisfied: odoo11-addon-l10n-es-account-asset==11.0.1.0.2 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 17))
Collecting odoo11-addon-l10n-es-account-bank-statement-import-n43==11.0.1.0.4 (from -r /opt/odoo_modules/requirements.txt (line 18))
  Using cached https://files.pythonhosted.org/packages/70/07/d0aa4537275b04d4bc69674aa7000b5248fe082bfd4620167525e1f31a9f/odoo11_addon_l10n_es_account_bank_statement_import_n43-11.0.1.0.4-py2.py3-none-any.whl
Collecting odoo11-addon-l10n-es-account-invoice-sequence==11.0.1.0.2.99.dev3 (from -r /opt/odoo_modules/requirements.txt (line 19))
  Using cached https://files.pythonhosted.org/packages/e2/8a/058bd97e424680b4017bf00b55f7735e1e6d86e22cd0afa94763f0875905/odoo11_addon_l10n_es_account_invoice_sequence-11.0.1.0.2.99.dev3-py2.py3-none-any.whl
Collecting odoo11-addon-l10n-es-aeat==11.0.2.0.1.99.dev2 (from -r /opt/odoo_modules/requirements.txt (line 20))
  Using cached https://files.pythonhosted.org/packages/b4/0b/13399353c894511c15384bb6211c39cfea12d0517e927994f280fcbc122b/odoo11_addon_l10n_es_aeat-11.0.2.0.1.99.dev2-py2.py3-none-any.whl
Requirement already satisfied: odoo11-addon-l10n-es-aeat-mod111==11.0.1.0.0 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 21))
Requirement already satisfied: odoo11-addon-l10n-es-aeat-mod115==11.0.1.0.0.99.dev4 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 22))
Collecting odoo11-addon-l10n-es-aeat-mod303==11.0.2.1.0 (from -r /opt/odoo_modules/requirements.txt (line 23))
  Using cached https://files.pythonhosted.org/packages/b8/cd/d3f26a9051ad19a62177e81f6c4574a7fcb625ff6e246f3514ab49308093/odoo11_addon_l10n_es_aeat_mod303-11.0.2.1.0-py2.py3-none-any.whl
Collecting odoo11-addon-l10n-es-aeat-mod349==11.0.1.1.3 (from -r /opt/odoo_modules/requirements.txt (line 24))
  Using cached https://files.pythonhosted.org/packages/77/4b/de0ad13b19237b0caf601dae7f0a27b5ab5c0dc50c1762fa62c341a1f124/odoo11_addon_l10n_es_aeat_mod349-11.0.1.1.3-py2.py3-none-any.whl
Collecting odoo11-addon-l10n-es-mis-report==11.0.2.2.0.99.dev4 (from -r /opt/odoo_modules/requirements.txt (line 25))
  Using cached https://files.pythonhosted.org/packages/b1/6c/d21cd5f4d4803e063325cd2534a0b558c7215a479a02cc63cf372a3a7345/odoo11_addon_l10n_es_mis_report-11.0.2.2.0.99.dev4-py2.py3-none-any.whl
Collecting odoo11-addon-l10n-es-partner==11.0.2.1.1 (from -r /opt/odoo_modules/requirements.txt (line 26))
  Using cached https://files.pythonhosted.org/packages/b0/e3/47b9a9af180fdf3de8d2ffd3b99e2446eb1883446995ff44e64b27095b6f/odoo11_addon_l10n_es_partner-11.0.2.1.1-py2.py3-none-any.whl
Requirement already satisfied: odoo11-addon-l10n-es-toponyms==11.0.1.0.0 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 27))
Collecting odoo11-addon-mis-builder==11.0.3.4.0 (from -r /opt/odoo_modules/requirements.txt (line 28))
  Using cached https://files.pythonhosted.org/packages/c1/4b/56c27061d57063c6896c97e66367e66c6e3ad294396b0148b02e870c0ded/odoo11_addon_mis_builder-11.0.3.4.0-py2.py3-none-any.whl
Requirement already satisfied: odoo11-addon-mis-builder-budget==11.0.3.3.0 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 29))
Collecting odoo11-addon-web-responsive==11.0.2.0.3 (from -r /opt/odoo_modules/requirements.txt (line 30))
  Using cached https://files.pythonhosted.org/packages/88/4f/ce99bc8a62c59b32c0f74861a39dd1876243066657be1d9415778e4c1704/odoo11_addon_web_responsive-11.0.2.0.3-py2.py3-none-any.whl
Requirement already satisfied: odoo11-addon-web-no-bubble==11.0.1.0.0 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 31))
Requirement already satisfied: odoo11-addon-web-searchbar-full-width==11.0.1.0.0 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 32))
Requirement already satisfied: odoo11-addon-web-environment-ribbon==11.0.1.0.2.99.dev2 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 33))
Requirement already satisfied: odoo11-addon-web-favicon==11.0.1.0.0.99.dev9 in /opt/.odoo_venv/lib/python3.6/site-packages (from -r /opt/odoo_modules/requirements.txt (line 34))
Requirement already satisfied: cssselect in /opt/.odoo_venv/lib/python3.6/site-packages (from openupgradelib->-r /opt/odoo_modules/requirements.txt (line 2))
Requirement already satisfied: lxml in /opt/.odoo_venv/lib/python3.6/site-packages (from openupgradelib->-r /opt/odoo_modules/requirements.txt (line 2))
Requirement already satisfied: odoo<11.1dev,>=11.0a in /opt/.odoo_venv/lib/python3.6/site-packages/odoo-11.0-py3.6.egg (from odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: unidecode in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo11-addon-account-banking-pain-base==11.0.1.0.1->-r /opt/odoo_modules/requirements.txt (line 4))
Requirement already satisfied: odoo11-addon-report-xlsx in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo11-addon-account-financial-report==11.0.2.4.3->-r /opt/odoo_modules/requirements.txt (line 8))
Requirement already satisfied: odoo11-addon-date-range in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo11-addon-account-financial-report==11.0.2.4.3->-r /opt/odoo_modules/requirements.txt (line 8))
Requirement already satisfied: chardet in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo11-addon-l10n-es-account-bank-statement-import-n43==11.0.1.0.4->-r /opt/odoo_modules/requirements.txt (line 18))
Requirement already satisfied: odoo11-addon-account-tax-balance in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo11-addon-l10n-es-aeat==11.0.2.0.1.99.dev2->-r /opt/odoo_modules/requirements.txt (line 20))
Requirement already satisfied: requests in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo11-addon-l10n-es-partner==11.0.2.1.1->-r /opt/odoo_modules/requirements.txt (line 26))
Requirement already satisfied: odoo11-addon-base-location-geonames-import in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo11-addon-l10n-es-toponyms==11.0.1.0.0->-r /opt/odoo_modules/requirements.txt (line 27))
Requirement already satisfied: odoo11-addon-web-widget-color in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo11-addon-mis-builder==11.0.3.4.0->-r /opt/odoo_modules/requirements.txt (line 28))
Requirement already satisfied: Jinja2 in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: babel>=1.0 in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: decorator in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: docutils in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: feedparser in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: gevent in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: html2text in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: mako in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: mock in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: ofxparse in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: passlib in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pillow in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: psutil in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: psycopg2>=2.2 in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pydot in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pyldap in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pyparsing in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pypdf2 in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pyserial in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: python-dateutil in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pytz in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pyusb>=1.0.0b1 in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pyyaml in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: qrcode in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: reportlab in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: suds-jurko in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: vatnumber in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: vobject in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: werkzeug in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: xlsxwriter in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: xlwt in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: xlrd in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo11-addon-report-xlsx->odoo11-addon-account-financial-report==11.0.2.4.3->-r /opt/odoo_modules/requirements.txt (line 8))
Requirement already satisfied: certifi>=2017.4.17 in /opt/.odoo_venv/lib/python3.6/site-packages (from requests->odoo11-addon-l10n-es-partner==11.0.2.1.1->-r /opt/odoo_modules/requirements.txt (line 26))
Requirement already satisfied: idna<2.8,>=2.5 in /opt/.odoo_venv/lib/python3.6/site-packages (from requests->odoo11-addon-l10n-es-partner==11.0.2.1.1->-r /opt/odoo_modules/requirements.txt (line 26))
Requirement already satisfied: urllib3<1.25,>=1.21.1 in /opt/.odoo_venv/lib/python3.6/site-packages (from requests->odoo11-addon-l10n-es-partner==11.0.2.1.1->-r /opt/odoo_modules/requirements.txt (line 26))
Requirement already satisfied: odoo11-addon-base-location in /opt/.odoo_venv/lib/python3.6/site-packages (from odoo11-addon-base-location-geonames-import->odoo11-addon-l10n-es-toponyms==11.0.1.0.0->-r /opt/odoo_modules/requirements.txt (line 27))
Requirement already satisfied: MarkupSafe>=0.23 in /opt/.odoo_venv/lib/python3.6/site-packages (from Jinja2->odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: greenlet>=0.4.9 in /opt/.odoo_venv/lib/python3.6/site-packages (from gevent->odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: six>=1.9 in /opt/.odoo_venv/lib/python3.6/site-packages (from mock->odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pbr>=0.11 in /opt/.odoo_venv/lib/python3.6/site-packages (from mock->odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: beautifulsoup4 in /opt/.odoo_venv/lib/python3.6/site-packages (from ofxparse->odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: olefile in /opt/.odoo_venv/lib/python3.6/site-packages (from pillow->odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: setuptools in /opt/.odoo_venv/lib/python3.6/site-packages (from pyldap->odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: pip>=1.4.1 in /opt/.odoo_venv/lib/python3.6/site-packages (from reportlab->odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: python-stdnum in /opt/.odoo_venv/lib/python3.6/site-packages (from vatnumber->odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Requirement already satisfied: soupsieve>=1.2 in /opt/.odoo_venv/lib/python3.6/site-packages (from beautifulsoup4->ofxparse->odoo<11.1dev,>=11.0a->odoo11-addon-account-banking-mandate==11.0.2.0.0.99.dev4->-r /opt/odoo_modules/requirements.txt (line 3))
Installing collected packages: odoo11-addon-account-payment-partner, odoo11-addon-account-payment-order, odoo11-addon-account-banking-mandate, odoo11-addon-account-banking-pain-base, odoo11-addon-account-banking-sepa-direct-debit, odoo11-addon-account-financial-report, odoo11-addon-base-technical-features, odoo11-addon-contract, odoo11-addon-contract-sale-invoicing, odoo11-addon-contract-variable-quantity, odoo11-addon-l10n-es-account-bank-statement-import-n43, odoo11-addon-l10n-es-account-invoice-sequence, odoo11-addon-l10n-es-aeat, odoo11-addon-l10n-es-aeat-mod303, odoo11-addon-l10n-es-aeat-mod349, odoo11-addon-mis-builder, odoo11-addon-l10n-es-mis-report, odoo11-addon-l10n-es-partner, odoo11-addon-web-responsive
  Found existing installation: odoo11-addon-account-payment-partner 11.0.1.2.1
    Uninstalling odoo11-addon-account-payment-partner-11.0.1.2.1:
      Successfully uninstalled odoo11-addon-account-payment-partner-11.0.1.2.1
  Found existing installation: odoo11-addon-account-payment-order 11.0.1.2.1
    Uninstalling odoo11-addon-account-payment-order-11.0.1.2.1:
      Successfully uninstalled odoo11-addon-account-payment-order-11.0.1.2.1
  Found existing installation: odoo11-addon-account-banking-mandate 11.0.1.2.2
    Uninstalling odoo11-addon-account-banking-mandate-11.0.1.2.2:
      Successfully uninstalled odoo11-addon-account-banking-mandate-11.0.1.2.2
  Found existing installation: odoo11-addon-account-banking-pain-base 11.0.1.0.0
    Uninstalling odoo11-addon-account-banking-pain-base-11.0.1.0.0:
      Successfully uninstalled odoo11-addon-account-banking-pain-base-11.0.1.0.0
  Found existing installation: odoo11-addon-account-banking-sepa-direct-debit 11.0.1.0.2
    Uninstalling odoo11-addon-account-banking-sepa-direct-debit-11.0.1.0.2:
      Successfully uninstalled odoo11-addon-account-banking-sepa-direct-debit-11.0.1.0.2
  Found existing installation: odoo11-addon-account-financial-report 11.0.1.2.0
    Uninstalling odoo11-addon-account-financial-report-11.0.1.2.0:
      Successfully uninstalled odoo11-addon-account-financial-report-11.0.1.2.0
  Found existing installation: odoo11-addon-base-technical-features 11.0.1.0.0.99.dev3
    Uninstalling odoo11-addon-base-technical-features-11.0.1.0.0.99.dev3:
      Successfully uninstalled odoo11-addon-base-technical-features-11.0.1.0.0.99.dev3
  Found existing installation: odoo11-addon-contract 11.0.2.1.0
    Uninstalling odoo11-addon-contract-11.0.2.1.0:
      Successfully uninstalled odoo11-addon-contract-11.0.2.1.0
  Found existing installation: odoo11-addon-contract-sale-invoicing 11.0.1.0.0
    Uninstalling odoo11-addon-contract-sale-invoicing-11.0.1.0.0:
      Successfully uninstalled odoo11-addon-contract-sale-invoicing-11.0.1.0.0
  Found existing installation: odoo11-addon-contract-variable-quantity 11.0.1.2.1
    Uninstalling odoo11-addon-contract-variable-quantity-11.0.1.2.1:
      Successfully uninstalled odoo11-addon-contract-variable-quantity-11.0.1.2.1
  Found existing installation: odoo11-addon-l10n-es-account-bank-statement-import-n43 11.0.1.0.1
    Uninstalling odoo11-addon-l10n-es-account-bank-statement-import-n43-11.0.1.0.1:
      Successfully uninstalled odoo11-addon-l10n-es-account-bank-statement-import-n43-11.0.1.0.1
  Found existing installation: odoo11-addon-l10n-es-account-invoice-sequence 11.0.1.0.1
    Uninstalling odoo11-addon-l10n-es-account-invoice-sequence-11.0.1.0.1:
      Successfully uninstalled odoo11-addon-l10n-es-account-invoice-sequence-11.0.1.0.1
  Found existing installation: odoo11-addon-l10n-es-aeat 11.0.1.0.1
    Uninstalling odoo11-addon-l10n-es-aeat-11.0.1.0.1:
      Successfully uninstalled odoo11-addon-l10n-es-aeat-11.0.1.0.1
  Found existing installation: odoo11-addon-l10n-es-aeat-mod303 11.0.2.0.2
    Uninstalling odoo11-addon-l10n-es-aeat-mod303-11.0.2.0.2:
      Successfully uninstalled odoo11-addon-l10n-es-aeat-mod303-11.0.2.0.2
  Found existing installation: odoo11-addon-l10n-es-aeat-mod349 11.0.1.0.5
    Uninstalling odoo11-addon-l10n-es-aeat-mod349-11.0.1.0.5:
      Successfully uninstalled odoo11-addon-l10n-es-aeat-mod349-11.0.1.0.5
  Found existing installation: odoo11-addon-mis-builder 11.0.3.3.0
    Uninstalling odoo11-addon-mis-builder-11.0.3.3.0:
      Successfully uninstalled odoo11-addon-mis-builder-11.0.3.3.0
  Found existing installation: odoo11-addon-l10n-es-mis-report 11.0.2.2.0
    Uninstalling odoo11-addon-l10n-es-mis-report-11.0.2.2.0:
      Successfully uninstalled odoo11-addon-l10n-es-mis-report-11.0.2.2.0
  Found existing installation: odoo11-addon-l10n-es-partner 11.0.2.0.0
    Uninstalling odoo11-addon-l10n-es-partner-11.0.2.0.0:
      Successfully uninstalled odoo11-addon-l10n-es-partner-11.0.2.0.0
  Found existing installation: odoo11-addon-web-responsive 11.0.1.0.2
    Uninstalling odoo11-addon-web-responsive-11.0.1.0.2:
      Successfully uninstalled odoo11-addon-web-responsive-11.0.1.0.2
Successfully installed odoo11-addon-account-banking-mandate-11.0.2.0.0.99.dev4 odoo11-addon-account-banking-pain-base-11.0.1.0.1 odoo11-addon-account-banking-sepa-direct-debit-11.0.1.0.3 odoo11-addon-account-financial-report-11.0.2.4.3 odoo11-addon-account-payment-order-11.0.1.3.3 odoo11-addon-account-payment-partner-11.0.1.3.0.99.dev12 odoo11-addon-base-technical-features-11.0.1.0.0.99.dev7 odoo11-addon-contract-11.0.4.1.0.99.dev4 odoo11-addon-contract-sale-invoicing-11.0.1.0.0.99.dev8 odoo11-addon-contract-variable-quantity-11.0.1.3.0.99.dev6 odoo11-addon-l10n-es-account-bank-statement-import-n43-11.0.1.0.4 odoo11-addon-l10n-es-account-invoice-sequence-11.0.1.0.2.99.dev3 odoo11-addon-l10n-es-aeat-11.0.2.0.1.99.dev2 odoo11-addon-l10n-es-aeat-mod303-11.0.2.1.0 odoo11-addon-l10n-es-aeat-mod349-11.0.1.1.3 odoo11-addon-l10n-es-mis-report-11.0.2.2.0.99.dev4 odoo11-addon-l10n-es-partner-11.0.2.1.1 odoo11-addon-mis-builder-11.0.3.4.0 odoo11-addon-web-responsive-11.0.2.0.3

```

**a task that uses the clean list, joined by commas**

```
    "cmd": [
        "/opt/.odoo_venv/bin/python",
        "/opt/odoo/odoo-bin",
        "-c",
        "/etc/odoo/odoo.conf",
        "-d",
        "calidoscoop",
        "--update",
        "account_banking_mandate,account_banking_pain_base,account_banking_sepa_direct_debit,account_financial_report,account_payment_order,account_payment_partner,base_technical_features,contract,contract_sale_invoicing,contract_variable_quantity,l10n_es_account_bank_statement_import_n43,l10n_es_account_invoice_sequence,l10n_es_aeat,l10n_es_aeat_mod303,l10n_es_aeat_mod349,l10n_es_mis_report,l10n_es_partner,mis_builder,web_responsive",
        "--stop-after-init",
        "--logfile=/dev/stdout",
        "--log-level=warn"
    ],
```