### PR TITLE
Don't set deprecating var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,8 +35,9 @@ odoo_role_odoo_log_path: /var/log/odoo
 odoo_role_odoo_log_level: debug
 odoo_role_loaded_languages: ca_ES,es_ES # Also available: eu_ES,gl_ES,pt_PT
 
-odoo_role_odoo_db_name: odoo
-odoo_role_odoo_dbs: [ "{{ odoo_role_odoo_db_name }}" ]
+# Read odoo_role_odoo_db_name or default to odoo. To deprecate the var, delete the active line and uncomment the one below this one.
+# odoo_role_odoo_dbs: [ "{{ odoo }}" ]
+odoo_role_odoo_dbs: [ "{{ odoo_role_odoo_db_name | default(odoo) }}" ]
 # This not a DB user password, but a password for Odoo to deal with DB.
 odoo_role_odoo_db_admin_password: iT0ohDuoth6ONgahDeepaich0aeka5ul
 # Give the chance to select a database before login not filtered out by dbfilter, and enable db manager web interface.


### PR DESCRIPTION
odoo-provisioning checker will discover it's set and will complain about it. By now, don't break funcionality and use it if present and the newer var is not present. Otherwise, ignore it.
This successfully removes the warning from odoo-provisioning (provision playbook)