### PR TITLE
Enable develop mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Odoo has a mode to auto-reload the server when the code changes and read the vie
 odoo_role_dev_mode: true
 ```
 If this mode is active, the systemd unit is not created and you need to run the Odoo process manually.
-You can start it with the next command:
+You can start it with the following command:
 
 ```sh
 $ ./odoo-bin -c /etc/odoo/odoo.conf --dev all

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Odoo has a mode to auto-reload the server when the code changes and read the vie
 ```yaml
 odoo_role_dev_mode: true
 ```
-If this mode is active, the systed unit is not created and you need run the Odoo process manyally.
+If this mode is active, the systemd unit is not created and you need to run the Odoo process manually.
 You can start it with the next command:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Odoo has a mode to auto-reload the server when the code changes and read the vie
 ```yaml
 odoo_role_dev_mode: true
 ```
+If this mode is active, the systed unit is not created and you need run the Odoo process manyally.
+You can start it with the next command:
+
+```sh
+$ ./odoo-bin -c /etc/odoo/odoo.conf --dev all
+```
 
 Community Roles
 ---------------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,4 @@
   service:
     name: "{{ odoo_daemon }}"
     state: restarted
+  when: not odoo_role_dev_mode | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -210,3 +210,4 @@
   when: odoo_role_dev_mode | bool
 
 - import_tasks: add-service.yml
+  when: not odoo_role_dev_mode | bool

--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -1,6 +1,8 @@
 [options]
 ; Log Settings
+{% if not odoo_role_dev_mode %}
 logfile = {{ odoo_role_odoo_log_path }}/odoo.log
+{% endif %}
 log_level = {{ odoo_role_odoo_log_level }}
 
 ; Custom Modules

--- a/templates/odoo.service.j2
+++ b/templates/odoo.service.j2
@@ -4,7 +4,7 @@
 Description=Odoo server
 
 [Service]
-ExecStart={{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf {% if odoo_role_dev_mode %} --dev all {% endif %}
+ExecStart={{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }} -c {{ odoo_role_odoo_config_path }}/odoo.conf
 
 # Execute service like user
 User={{ odoo_role_odoo_user }}


### PR DESCRIPTION
When we are in development mode we need:

* Reload the server in any code change
* Write the output of the Odoo process in the stdout instead of in a log file.
* Run the process manually instead of with a service.