### PR TITLE
Update the URL to download the wkhtmltopdf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: Download and install wkhtmltopdf only if not already present at any version
   apt:
-    deb: "https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.{{ ansible_distribution_release }}_amd64.deb"
+    deb: "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.{{ ansible_distribution_release }}_amd64.deb"
   when: wkhtmltox_installed.rc == 1
 
 - import_tasks: pyenv.yml


### PR DESCRIPTION
The releases of wkhtmltopdf was moved to Github in 06/11:

https://wkhtmltopdf.org/downloads.html