### PR TITLE
Add Rest Framework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ You can start it with the following command:
 $ ./odoo-bin -c /etc/odoo/odoo.conf --dev all
 ```
 
+* [Rest Framework](https://github.com/OCA/rest-framework/tree/12.0/base_rest) support
+
+If you need to use the Rest Framework and want to start the server in development mode, use:
+```yaml
+odoo_role_enable_rest_framework: true
+```
+
+This option add to the Odoo configuration file the section and option to development mode: https://github.com/OCA/rest-framework/tree/12.0/base_rest#configuration
+
 Community Roles
 ---------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,3 +63,6 @@ odoo_role_dev_mode: false
 # HTTP server settings
 odoo_role_odoo_http_interface: "127.0.0.1"
 odoo_role_odoo_proxy_mode: true
+
+# Support for rest-framework/base_rest: https://github.com/OCA/rest-framework/tree/12.0/base_rest
+odoo_role_enabled_rest_framework: false

--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -36,3 +36,8 @@ unaccent = True
 
 ; Hack to avoid LC_COLLATE="C"
 db_template = template1
+
+{% if odoo_role_dev_mode and odoo_role_enabled_rest_framework %}
+[base_rest]
+dev_mode=True
+{% endif %}


### PR DESCRIPTION
Add option to activate the rest framework development mode following the
next documentation:
https://github.com/OCA/rest-framework/tree/12.0/base_rest#configuration