### PR TITLE
Set the db_port in Odoo configuration if is defined

### DIFF
--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -37,6 +37,10 @@ list_db = True
 list_db = {{ odoo_role_list_db }}
 {% endif %}
 
+{% if odoo_role_db_port is defined %}
+db_port = {{ odoo_role_db_port }}
+{% endif %}
+
 ; Ignore accents in searchs
 unaccent = True
 

--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -37,7 +37,7 @@ list_db = True
 list_db = {{ odoo_role_list_db }}
 {% endif %}
 
-{% if odoo_role_db_port is defined %}
+{% if odoo_role_db_port %}
 db_port = {{ odoo_role_db_port }}
 {% endif %}
 


### PR DESCRIPTION
We need this feature to connect the Odoo application to Postgresql with a custom TCP/IP port.

We use a socket connection, but PostgreSQL uses the port in the socket name, and Odoo has `5432` as default `db_port`.

When Odoo try to connect to the db needs the real TCP/IP port to find the socket.