### PR TITLE
Allow to customize the Odoo timeouts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,3 +71,7 @@ odoo_role_enabled_rest_framework: false
 odoo_role_enable_queue_job: false
 # Support for Dbfilter From Header https://github.com/OCA/server-tools/tree/12.0/dbfilter_from_header
 odoo_role_enable_dbfilter_from_header: false
+
+# Customize the Odoo timeouts
+odoo_role_limit_time_cpu: 60
+odoo_role_limit_time_real: 120

--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -52,6 +52,10 @@ db_template = template1
 workers = {{ odoo_role_workers }}
 {% endif %}
 
+; Customize the Odoo timeouts
+limit_time_cpu = {{ odoo_role_limit_time_cpu }}
+limit_time_real = {{ odoo_role_limit_time_real }}
+
 {% if odoo_role_enable_queue_job and odoo_role_channels %}
 [queue_job]
 channels = {{ odoo_role_channels }}


### PR DESCRIPTION
Expose the configurations limit_time_real and limit_time_cpu to be set in the Odoo
config.