### PR TITLE
Don't start HTTP server in Odoo modules update task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -209,6 +209,7 @@
     --stop-after-init
     --logfile=/dev/stdout
     --log-level=warn
+    --no-http
   when: reg_pip_upgraded.stdout
   with_items: "{{ odoo_role_odoo_dbs }}"
   notify: restart odoo


### PR DESCRIPTION
To avoid the error: `OSError: [Errno 98] Address already in use` when we try to update a module with the role, we add the `--no-http` option to the update command.

This option do not start the HTTP or long-polling workers (may still start cron workers) avoiding the error with the already in use port.

https://www.odoo.com/documentation/12.0/reference/cmdline.html