### PR TITLE
Chek if odoo_role_workers is defined to fix AnsibleUndefinedVariable error

### DIFF
--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -47,7 +47,7 @@ unaccent = True
 ; Hack to avoid LC_COLLATE="C"
 db_template = template1
 
-{% if odoo_role_workers and odoo_role_workers > 1 %}
+{% if odoo_role_workers is defined and odoo_role_workers > 1 %}
 ; If workers > 1 are defined, add a /location in Nginx server for LongPolling
 workers = {{ odoo_role_workers }}
 {% endif %}


### PR DESCRIPTION
The var `odoo_role_workers` is optional, and we don't define a default value for it.

Checking if the var is defined we can fix the issue #99.

In Jinja2 we can use the `define` function to check if a var is defined: https://jinja.palletsprojects.com/en/2.11.x/templates/#defined

Fix #99