### PR TITLE
Add handler to remove the Odoo sessions after a deploy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,3 +79,8 @@ odoo_role_limit_time_real: 120
 
 # Force getting db name from leftmost subdomain (different inventories for each DB)
 odoo_role_force_leftmost_subdomain: false
+
+# Sessions path: data_dir/sessions
+# https://github.com/OCA/OCB/blob/12.0/odoo/tools/appdirs.py#L48
+odoo_role_odoo_sessions_path: "/home/{{ odoo_role_odoo_user }}/.local/share/Odoo/sessions"
+odoo_role_remove_sessions: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,17 @@
     name: "{{ odoo_daemon }}"
     state: restarted
   when: not odoo_role_dev_mode | bool
+
+- name: remove sessions
+  file:
+    state: "{{ item }}"
+    path: "{{ odoo_role_odoo_sessions_path }}"
+    owner: "{{ odoo_role_odoo_user }}"
+    group:  "{{ odoo_role_odoo_group }}"
+    mode: '0775'
+  with_items:
+    - absent
+    - directory
+  when:
+    - not odoo_role_dev_mode | bool
+    - odoo_role_remove_sessions | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -215,7 +215,9 @@
   with_items: "{{ odoo_role_odoo_dbs }}"
   loop_control:
     index_var: index
-  notify: restart odoo
+  notify:
+    - restart odoo
+    - remove sessions
 
 - name: Update in Odoo pip upgraded community modules
   become: yes
@@ -232,7 +234,9 @@
     --no-http
   when: reg_pip_upgraded.stdout
   with_items: "{{ odoo_role_odoo_dbs }}"
-  notify: restart odoo
+  notify:
+    - restart odoo
+    - remove sessions
 
 - name: Set ribbon name for test dbs
   become: yes


### PR DESCRIPTION
We need to force the users to restart the session after every deploy to get and use the last changes introduced with the new version.

The sessions are saved in the `data_dir/sessions`.

Removing all the sessions force the users to login again.

We add the flag `odoo_role_remove_sessions` to use the handler.