### PR TITLE
Allow path to requirements.txt for community modules to be configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,10 @@ odoo_role_dbfilter_enabled: True
 # Comma-separated list of modules to install before running the server
 odoo_role_odoo_core_modules: "base"
 
+# path of where to find the community modules requirements.txt
+odoo_role_community_modules_requirements_path: "{{ inventory_dir }}/../files/requirements.txt"
+
+
 odoo_daemon: "odoo.service"
 
 # Whether to populate db with example data or not.

--- a/tasks/community-modules.yml
+++ b/tasks/community-modules.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copy requirements.txt
-  copy: # 'noqa' below disables [E404] Don’t compare to empty string
-    src: "{{ inventory_dir }}/../files/requirements.txt" # noqa 404
+  copy:
+    src: "{{ odoo_role_community_modules_requirements_path }}"
     dest: "{{ odoo_role_odoo_modules_path }}/requirements.txt"
     owner: "{{ odoo_role_odoo_user }}"
     group: "{{ odoo_role_odoo_group }}"


### PR DESCRIPTION
This small patch allows to set the path where the requirements.txt for community modules resides.
The original path `{{ inventory_dir }}/../files/requirements.txt` may not always be fitting, if you for example have a more complex inventories structure with a lot of sub-directories.
By having the possibility to override through inventory this is more flexible.