### PR TITLE
Fix wrong variable definition in odoo.conf.j2

### DIFF
--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -68,6 +68,6 @@ dev_mode=True
 
 {% if odoo_role_enable_sentry and odoo_role_sentry_dsn %}
 [sentry]
-sentry_dsn = odoo_role_sentry_dsn
+sentry_dsn = {{ odoo_role_sentry_dsn }}
 sentry_enabled = True
 {% endif %}


### PR DESCRIPTION
Fix missing "{{" in odoo_role_sentry_dsn variable to make it substitute by value defined in .conf file