### PR TITLE
Add the option to overwrite the translations in the modules updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ odoo_role_enable_sentry: true
 odoo_role_sentry_dsn: https://your_sentry_url
 ```
 
+* i18n Overwrite
+
+We can force the i18n overwrite using the next variable:
+```yaml
+odoo_role_i18n_overwrite: true
+```
+
+You can define this var in the inventory or use it when execute a playbook:
+
+```
+ansible-playbook playbooks/provision.yml -i ../my-inventory/inventory/hosts --ask-vault-pass --limit=host -e "{odoo_role_i18n_overwrite: true}"
+```
+
 * Environment variables
 
 If you need to define a set of environment variables for your server, you can use the `environment_variables` dict var:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,3 +91,7 @@ odoo_role_remove_sessions: false
 
 odoo_role_odoo_community_modules: ""
 odoo_role_enable_sentry: false
+
+# Overwrites existing translation terms on updating a module or importing a CSV or a PO file using the option --i18n-overwrite in the module update.
+# https://www.odoo.com/documentation/12.0/developer/reference/cmdline.html#cmdoption-odoo-bin-i18n-overwrite
+odoo_role_i18n_overwrite: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -252,6 +252,9 @@
     --logfile=/dev/stdout
     --log-level=warn
     --no-http
+    {% if odoo_role_i18n_overwrite %}
+    --i18n-overwrite
+    {% endif %}
   when: reg_pip_upgraded.stdout
   with_items: "{{ odoo_role_odoo_dbs }}"
   notify:


### PR DESCRIPTION
Add a var to manage the translations overwrite.

```
odoo_role_i18n_overwrite: true
```

Using this var we can force the `--i18n-overwrite` option of the Odoo CLI: https://www.odoo.com/documentation/12.0/developer/reference/cmdline.html#cmdoption-odoo-bin-i18n-overwrite

Fixes #125