### PR TITLE
Install libjpeg-dev for Odoo 12 as well

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,7 +100,7 @@
       - nodejs
       - npm
     state: present
-  when: odoo_role_odoo_version < "12.0"
+  when: odoo_role_odoo_version < "13.0"
 
 - name: Install Less CSS via nodejs
   become: yes
@@ -108,7 +108,7 @@
     name: less
     version: 2.7.2
     global: yes
-  when: odoo_role_odoo_version < "12.0"
+  when: odoo_role_odoo_version < "13.0"
 
 # This link is needed in Ubuntu 16.04 and in Ubuntu 18.04 raise an error.
 - name: Create node symlink

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     pkg:
       - libjpeg-dev
     state: present
-  when: odoo_role_odoo_version < "12.0"
+  when: odoo_role_odoo_version < "13.0"
 
 - name: Check if wkhtmltopdf is installed
   shell: set -o pipefail && dpkg -s wkhtmltox | grep 'install ok installed'

--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -12,7 +12,7 @@ server_wide_modules = web,dbfilter_from_header
 server_wide_modules = web,dbfilter_from_header,queue_job
 {% endif %}
 ; Custom Modules
-addons_path = {{ odoo_role_odoo_path }}/addons,{{ odoo_role_odoo_modules_path }}
+addons_path = {{ odoo_role_odoo_path }}/addons,{{ odoo_role_odoo_modules_path }},/opt/odoo-custom
 
 ; Master password to manage dbs
 admin_passwd = {{ odoo_role_odoo_db_admin_password }}
@@ -45,7 +45,7 @@ db_port = {{ odoo_role_db_port }}
 unaccent = True
 
 ; Hack to avoid LC_COLLATE="C"
-db_template = template1
+;db_template = template1
 
 {% if odoo_role_workers is defined and odoo_role_workers > 1 %}
 ; If workers > 1 are defined, add a /location in Nginx server for LongPolling


### PR DESCRIPTION
Installing Odoo 12 on Ubuntu 20.04LTS requires libjpeg-dev as well (at least with my requirements.txt).