### PR TITLE
Change order of jobs update and install modules

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -197,6 +197,25 @@
     core_modules: "{{ core_modules | default({}) | combine ({ item : core_shared_modules + core_db_modules[item] }) }}"
   with_items: "{{ odoo_role_odoo_dbs }}"
 
+- name: Update in Odoo pip upgraded community modules
+  become: yes
+  become_user: "{{ odoo_role_odoo_user }}"
+  environment: "{{ environment_variables | default({}) }}"
+  command: >
+    {{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }}
+    -c {{ odoo_role_odoo_config_path }}/odoo.conf
+    -d {{ item }}
+    --update {{ reg_pip_upgraded.stdout_lines | join(',') }}
+    --stop-after-init
+    --logfile=/dev/stdout
+    --log-level=warn
+    --no-http
+  when: reg_pip_upgraded.stdout
+  with_items: "{{ odoo_role_odoo_dbs }}"
+  notify:
+    - restart odoo
+    - remove sessions
+
 - name: Build the list of new modules to install
   become: yes
   become_user: "{{ odoo_role_odoo_user }}"
@@ -235,28 +254,6 @@
   with_items: "{{ odoo_role_odoo_dbs }}"
   loop_control:
     index_var: index
-  notify:
-    - restart odoo
-    - remove sessions
-
-- name: Update in Odoo pip upgraded community modules
-  become: yes
-  become_user: "{{ odoo_role_odoo_user }}"
-  environment: "{{ environment_variables | default({}) }}"
-  command: >
-    {{ odoo_role_odoo_python_path }} {{ odoo_role_odoo_bin_path }}
-    -c {{ odoo_role_odoo_config_path }}/odoo.conf
-    -d {{ item }}
-    --update {{ reg_pip_upgraded.stdout_lines | join(',') }}
-    --stop-after-init
-    --logfile=/dev/stdout
-    --log-level=warn
-    --no-http
-    {% if odoo_role_i18n_overwrite %}
-    --i18n-overwrite
-    {% endif %}
-  when: reg_pip_upgraded.stdout
-  with_items: "{{ odoo_role_odoo_dbs }}"
   notify:
     - restart odoo
     - remove sessions


### PR DESCRIPTION
Move job "Update in Odoo pip upgraded community modules" before job "Install only new Odoo modules" in order to avoid provisioning errors.