### PR TITLE
Install libjpeg-dev for Odoo 12 as well (erroneous commits removed)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     pkg:
       - libjpeg-dev
     state: present
-  when: odoo_role_odoo_version < "12.0"
+  when: odoo_role_odoo_version < "13.0"
 
 - name: Check if wkhtmltopdf is installed
   shell: set -o pipefail && dpkg -s wkhtmltox | grep 'install ok installed'


### PR DESCRIPTION
Installing Odoo 12 on Ubuntu 20.04LTS requires libjpeg-dev as well (at least with my requirements.txt).

This replaces PR #128 which included unintended commits.