### PR TITLE
Handle odoo server wide modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ odoo_role_enable_queue_job: true
 
 This option add to the Odoo configuration file the option to enable queue\_job as a new thread/process: https://github.com/OCA/queue/blob/12.0/queue\_job/README.rst#id12
 
+* Server-wide modules  
+
+If you need to install some wide-server modules apart from `db_filter` and `queue_job`, use:
+```yaml
+odoo_role_odoo_server_wide_modules: ['module1', 'module2']
+```
+
+By default, it configures as a server-wide modules `web` and `base` -as long as they are mandatory from Odoo v12- in every case and `db_filter` and `queue_job` if the corresponding variables are set to `true` .
+
+* Workers configuration
+
 You can also define how many workers you want to use to execute the jobs:
 ```yaml
 odoo_role_channels: root:2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,8 @@ odoo_role_enabled_rest_framework: false
 odoo_role_enable_queue_job: false
 # Support for Dbfilter From Header https://github.com/OCA/server-tools/tree/12.0/dbfilter_from_header
 odoo_role_enable_dbfilter_from_header: false
+# Support for loading system-wide modules
+odoo_role_odoo_server_wide_modules: ["base","web"]
 
 # Customize the Odoo timeouts
 odoo_role_limit_time_cpu: 60

--- a/tasks/check-role-conf.yml
+++ b/tasks/check-role-conf.yml
@@ -4,12 +4,6 @@
     odoo_role_odoo_server_wide_modules: "{{ odoo_role_odoo_server_wide_modules + ['dbfilter_from_header'] }}"
   when: odoo_role_enable_dbfilter_from_header | bool
   tags: ['server-wide']
-
-- name: Generate server wide modules configuration  (queue_job)
-  set_fact:
-    odoo_role_odoo_server_wide_modules: "{{ odoo_role_odoo_server_wide_modules + ['queue_job'] }}"
-  when: odoo_role_enable_queue_job | bool
-  tags: ['server-wide']
   
 - name: Check requirements for db_filter (odoo_role_channels)
   ansible.builtin.fail:
@@ -17,21 +11,14 @@
   when: odoo_role_enable_dbfilter_from_header | bool and odoo_role_channels is not defined
   tags: ['server-wide']
 
-- name: Extract databases from modules_dict
+- name: Generate server wide modules configuration  (queue_job)
   ansible.builtin.set_fact:
-     odoo_role_database_plugins: "{{ odoo_role_database_plugins | default([]) + [ item ] }}"     
-  with_items: "{{ odoo_role_odoo_community_modules_dict }}"
+    odoo_role_odoo_server_wide_modules: "{{ odoo_role_odoo_server_wide_modules + ['queue_job'] }}"
+  when: odoo_role_enable_queue_job | bool
   tags: ['server-wide']
 
 - name: Check if server_wide modules are declared  
-  ansible.builtin.set_fact:
-     odoo_role_all_plugins: "{{  odoo_role_all_plugins | default([]) + [ odoo_role_odoo_community_modules_dict[item] ] | flatten }}"
-  with_items: "{{ odoo_role_database_plugins }}"
-  tags: ['server-wide']
-
-- name: Require server_wide_modules to be declared
   ansible.builtin.fail:
-     msg: "Role Error: odoo_role_odoo_server_wide_modules are declared but not present on odoo_role_odoo_community_modules_dict"
+    msg: "Role Error: {{ item }} module is configured as a server wide module but it is not present in modules dict"
   with_items: "{{ odoo_role_odoo_server_wide_modules }}"
-  when: (item not in odoo_role_all_plugins) and (item != 'base' and item != 'web')
-  tags: ['server-wide']
+  when: (item not in odoo_role_odoo_community_modules_dict['shared']) and (item != 'web') and (item != 'base')

--- a/tasks/check-role-conf.yml
+++ b/tasks/check-role-conf.yml
@@ -1,0 +1,37 @@
+---
+- name: Generate server wide modules configuration (db_filter_from_header)
+  set_fact:
+    odoo_role_odoo_server_wide_modules: "{{ odoo_role_odoo_server_wide_modules + ['dbfilter_from_header'] }}"
+  when: odoo_role_enable_dbfilter_from_header | bool
+  tags: ['server-wide']
+
+- name: Generate server wide modules configuration  (queue_job)
+  set_fact:
+    odoo_role_odoo_server_wide_modules: "{{ odoo_role_odoo_server_wide_modules + ['queue_job'] }}"
+  when: odoo_role_enable_queue_job | bool
+  tags: ['server-wide']
+  
+- name: Check requirements for db_filter (odoo_role_channels)
+  ansible.builtin.fail:
+    msg: "Role Error: odoo_role_channels var is needed when queue_job is activated" # not required. The customized message that is printed. If omitted, prints a generic message.
+  when: odoo_role_enable_dbfilter_from_header | bool and odoo_role_channels is not defined
+  tags: ['server-wide']
+
+- name: Extract databases from modules_dict
+  ansible.builtin.set_fact:
+     odoo_role_database_plugins: "{{ odoo_role_database_plugins | default([]) + [ item ] }}"     
+  with_items: "{{ odoo_role_odoo_community_modules_dict }}"
+  tags: ['server-wide']
+
+- name: Check if server_wide modules are declared  
+  ansible.builtin.set_fact:
+     odoo_role_all_plugins: "{{  odoo_role_all_plugins | default([]) + [ odoo_role_odoo_community_modules_dict[item] ] | flatten }}"
+  with_items: "{{ odoo_role_database_plugins }}"
+  tags: ['server-wide']
+
+- name: Require server_wide_modules to be declared
+  ansible.builtin.fail:
+     msg: "Role Error: odoo_role_odoo_server_wide_modules are declared but not present on odoo_role_odoo_community_modules_dict"
+  with_items: "{{ odoo_role_odoo_server_wide_modules }}"
+  when: (item not in odoo_role_all_plugins) and (item != 'base' and item != 'web')
+  tags: ['server-wide']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,10 +125,51 @@
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
   when: odoo_role_desired_tar_download.changed or odoo_role_desired_git_download.changed
 
+- name: Populate community db modules
+  set_fact:
+    community_db_modules: "{{ community_db_modules | default({}) | combine ({ item : odoo_role_odoo_community_modules_dict[item] | default([]) }) }}"
+  with_items: "{{ odoo_role_odoo_dbs }}"
+
+- name: Populate community shared modules
+  set_fact:
+    community_shared_modules: "{{ odoo_role_odoo_community_modules_dict['shared'] | default(odoo_role_odoo_community_modules.split(',')) }}"
+
+- name: Join db + shared community modules
+  set_fact:
+    community_modules: "{{ community_modules | default({}) | combine ({ item : community_shared_modules + community_db_modules[item] }) }}"
+  with_items: "{{ odoo_role_odoo_dbs }}"
+
+- name: Populate core db modules
+  set_fact:
+    core_db_modules: "{{ core_db_modules | default({}) | combine ({ item : odoo_role_odoo_core_modules_dict[item] | default([]) }) }}"
+  with_items: "{{ odoo_role_odoo_dbs }}"
+
+- name: Populate core shared modules
+  set_fact:
+    core_shared_modules: "{{ odoo_role_odoo_core_modules_dict['shared'] | default(odoo_role_odoo_core_modules.split(',')) }}"
+
+- name: Join db + shared core modules
+  set_fact:
+    core_modules: "{{ core_modules | default({}) | combine ({ item : core_shared_modules + core_db_modules[item] }) }}"
+  with_items: "{{ odoo_role_odoo_dbs }}"
+
+- name: Join core + community modules
+  set_fact:
+    modules: "{{ modules | default([]) + item.value }}"
+  with_dict:
+    - "{{ core_modules }}"
+    - "{{ community_modules }}"
+  no_log: True
+
+- name: Create unique list of modules
+  set_fact:
+    all_modules: "{{ modules | unique | sort }}"
+  when: modules is defined
+
 - name: Check server wide configuration
-  import_tasks: check-role-conf.yml
+  import_tasks: server-wide-conf.yml
   tags: ['server-wide']
-  
+
 - name: Add Odoo config
   become: true
   template:
@@ -172,34 +213,6 @@
     index_var: index
 
 - import_tasks: community-modules.yml
-
-- name: Populate community db modules
-  set_fact:
-    community_db_modules: "{{ community_db_modules | default({}) | combine ({ item : odoo_role_odoo_community_modules_dict[item] | default([]) }) }}"
-  with_items: "{{ odoo_role_odoo_dbs }}"
-
-- name: Populate community shared modules
-  set_fact:
-    community_shared_modules: "{{ odoo_role_odoo_community_modules_dict['shared'] | default(odoo_role_odoo_community_modules.split(',')) }}"
-
-- name: Join db + shared community modules
-  set_fact:
-    community_modules: "{{ community_modules | default({}) | combine ({ item : community_shared_modules + community_db_modules[item] }) }}"
-  with_items: "{{ odoo_role_odoo_dbs }}"
-
-- name: Populate core db modules
-  set_fact:
-    core_db_modules: "{{ core_db_modules | default({}) | combine ({ item : odoo_role_odoo_core_modules_dict[item] | default([]) }) }}"
-  with_items: "{{ odoo_role_odoo_dbs }}"
-
-- name: Populate core shared modules
-  set_fact:
-    core_shared_modules: "{{ odoo_role_odoo_core_modules_dict['shared'] | default(odoo_role_odoo_core_modules.split(',')) }}"
-
-- name: Join db + shared core modules
-  set_fact:
-    core_modules: "{{ core_modules | default({}) | combine ({ item : core_shared_modules + core_db_modules[item] }) }}"
-  with_items: "{{ odoo_role_odoo_dbs }}"
 
 - name: Force update odoo modules
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,6 +125,10 @@
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
   when: odoo_role_desired_tar_download.changed or odoo_role_desired_git_download.changed
 
+- name: Check server wide configuration
+  import_tasks: check-role-conf.yml
+  tags: ['server-wide']
+  
 - name: Add Odoo config
   become: true
   template:

--- a/tasks/server-wide-conf.yml
+++ b/tasks/server-wide-conf.yml
@@ -21,4 +21,5 @@
   ansible.builtin.fail:
     msg: "Role Error: {{ item }} module is configured as a server wide module but it is not present in modules dict"
   with_items: "{{ odoo_role_odoo_server_wide_modules }}"
-  when: (item not in odoo_role_odoo_community_modules_dict['shared']) and (item != 'web') and (item != 'base')
+  when: (item not in all_modules)
+  tags: ['server-wide']

--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -4,13 +4,7 @@
 logfile = {{ odoo_role_odoo_log_path }}/odoo.log
 {% endif %}
 log_level = {{ odoo_role_odoo_log_level }}
-{% if odoo_role_enable_queue_job and not odoo_role_enable_dbfilter_from_header %}
-server_wide_modules = web,queue_job
-{% elif not odoo_role_enable_queue_job and odoo_role_enable_dbfilter_from_header %}
-server_wide_modules = web,dbfilter_from_header
-{% elif odoo_role_enable_queue_job and odoo_role_enable_dbfilter_from_header %}
-server_wide_modules = web,dbfilter_from_header,queue_job
-{% endif %}
+server_wide_modules = {{ odoo_role_odoo_server_wide_modules | join(',') }}
 ; Custom Modules
 addons_path = {{ odoo_role_odoo_modules_path }}, {{ odoo_role_odoo_path }}/addons
 


### PR DESCRIPTION
Add configuration to enable server wide modules beyond that `dbfilter_from_header`and `queue_job`

- [X] Allow adding new wide-server modules directly
- [X] Check that wide-server modules are listed in inventory
- [X] Check that workers are configured if 
- [X] Document new parameters in `README`
