### PR TITLE
fix: conditional wkhtmltox version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -111,3 +111,8 @@ odoo_role_logrotate_odoo:
              compress
              delaycompress
       }
+
+# wkhtmltopdf version
+wkhtmltox_version_jammy: "0.12.6.1-2"
+wkhtmltox_version_bionic: "0.12.6.1"
+wkhtmltox_version: "{% if ansible_distribution_release in ['jammy', 'bullseye'] %}{{ wkhtmltox_version_jammy }}{% else %}{{wkhtmltox_version_bionic}}{% endif %}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -114,5 +114,5 @@ odoo_role_logrotate_odoo:
 
 # wkhtmltopdf version
 wkhtmltox_version_jammy: "0.12.6.1-2"
-wkhtmltox_version_bionic: "0.12.6.1"
+wkhtmltox_version_bionic: "0.12.6-1"
 wkhtmltox_version: "{% if ansible_distribution_release in ['jammy', 'bullseye'] %}{{ wkhtmltox_version_jammy }}{% else %}{{wkhtmltox_version_bionic}}{% endif %}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - name: Download and install wkhtmltopdf only if not already present at any version
   apt:
-    deb: "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.{{ ansible_distribution_release }}_amd64.deb"
+    deb: "https://github.com/wkhtmltopdf/packaging/releases/download/{{ wkhtmltox_version }}/wkhtmltox_{{ wkhtmltox_version }}.{{ ansible_distribution_release }}_amd64.deb"
   when: wkhtmltox_installed.rc == 1
 
 - import_tasks: pyenv.yml


### PR DESCRIPTION
Allow to set different versions of `wkhtmltox` package based on the OS release. 
Read more in: https://github.com/wkhtmltopdf/packaging/issues/137

Fix #147