### PR TITLE
Create python packages requirements.txt file from template

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,28 +227,46 @@ This tag helps you install or update Odoo modules without performing a full setu
 ansible-playbook playbook.yml --tags "only-modules"
 ```
 
-Community Roles
----------------
+Odoo modules
+------------
 
 #### Deploy
-To use community roles, you need to deploy this modules in the server. This role manage the modules deployment with `pip`.
+To use Odoo modules (from OCA or custom modules), you need to deploy modules packages to the server. This role manages the modules deployment with `pip`.
+In your inventory you can define up to two variables in order to add python packages to the target `requirements.txt` that will be generated.
 
-You can define a `requirements.txt` file to manage the modules and ensure the version installed:
+Define the `odoo_role_odoo_community_packages` variable to install packages not maintained by you. For example when you're deploying an Odoo instance that just requires OCA modules:
 
+```yml
+# inventory/group_vars/all.yml
+odoo_role_odoo_community_packages:
+  - odoo11-addon-contract==11.0.2.1.0
+  - odoo11-addon-contract-sale-invoicing==11.0.1.0.0
+  - odoo11-addon-contract-variable-qty-timesheet==11.0.1.0.0
+  - odoo11-addon-contract-variable-quantity==11.0.1.2.1
 ```
-# requirements.txt
-odoo11-addon-contract==11.0.2.1.0
-odoo11-addon-contract-sale-invoicing==11.0.1.0.0
-odoo11-addon-contract-variable-qty-timesheet==11.0.1.0.0
-odoo11-addon-contract-variable-quantity==11.0.1.2.1
+
+In some case you want to deploy different versions of the same module to different hosts.
+A typical case is when you have developed a custom module and need to deploy a packaged version of it to production but in local development environment you need to install it es editable.
+In this case you can define the `odoo_role_odoo_project_packages` variable:
+```yml
+# inventory/host_vars/production.yml
+odoo_role_odoo_project_packages:
+  - odoo14-my-custom-module==14.0.0.1.0
 ```
 
-> The default the `requirements.txt` file path is `"{{ inventory_dir }}/../files/requirements.txt"`.
+```yml
+# inventory/host_vars/development.yml
+odoo_role_odoo_project_packages:
+  - '-e file:///opt/odoo_modules/setup/my_custom_module'
+```
 
-# Install
-Once the modules are in the server, you need to install them in the database.
+For backward compatibility, the Ansible template will look first for a `files/requirements.txt` file in your inventory and use it as the source of the template.
+If you have a `files/requirements.txt` file defined in your inventory, the two variables just described will not take any effect.
 
-Define a `odoo_role_odoo_community_modules` var with the list of the modules names you want to install.
+#### Install
+Once the modules packages are installed in the server, you need to install them in the Odoo database.
+
+Define a `odoo_role_odoo_community_modules` variable with the list of the modules names you want to install.
 
 ```yml
 # inventory/group_vars/all.yml

--- a/tasks/community-modules.yml
+++ b/tasks/community-modules.yml
@@ -1,11 +1,15 @@
 ---
-- name: Copy requirements.txt
-  copy:
-    src: "{{ odoo_role_community_modules_requirements_path }}"
+- name: Create requirements.txt from template
+  ansible.builtin.template:
+    src: "{{ lookup('ansible.builtin.first_found', template_sources) }}"
     dest: "{{ odoo_role_odoo_modules_path }}/requirements.txt"
     owner: "{{ odoo_role_odoo_user }}"
     group: "{{ odoo_role_odoo_group }}"
     mode: 0644
+  vars:
+    template_sources:
+      - "{{ inventory_dir }}/../files/requirements.txt"
+      - templates/requirements.txt.j2
   tags: ['community-modules', 'only-modules']
 
 - name: Deploy community roles with pip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -119,11 +119,19 @@
     state: link
   when: odoo_role_odoo_version < "12.0" and ansible_distribution == "Ubuntu" and not ansible_distribution_version >= "18.04"
 
+- name: Check if Odoo is already installed in virtualenv
+  become: true
+  become_user: "{{ odoo_role_odoo_user }}"
+  ansible.builtin.shell: >
+    {{ odoo_role_odoo_python_path }} -m pip list | grep odoo
+  register: odoo_package_is_installed
+  failed_when: odoo_package_is_installed.rc not in [0,1]
+
 - name: Install Odoo
   become: true
   become_user: "{{ odoo_role_odoo_user }}"
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
-  when: odoo_role_desired_tar_download.changed or odoo_role_desired_git_download.changed
+  when: odoo_role_desired_tar_download.changed or odoo_role_desired_git_download.changed or odoo_package_is_installed.stdout == ''
 
 - name: Populate community db modules
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -119,13 +119,26 @@
     state: link
   when: odoo_role_odoo_version < "12.0" and ansible_distribution == "Ubuntu" and not ansible_distribution_version >= "18.04"
 
+
 - name: Check if Odoo is already installed in virtualenv
   become: true
   become_user: "{{ odoo_role_odoo_user }}"
   ansible.builtin.shell: >
     {{ odoo_role_odoo_python_path }} -m pip show odoo
-  register: odoo_package_is_installed
+  register: odoo_package_check
   failed_when: odoo_package_is_installed.rc not in [0,1]
+  
+- name: Set boolean for Odoo package installation
+  set_fact:
+    odoo_package_not_installed: "{{ odoo_package_check.rc == 1 }}"
+    
+- name: Determine if Odoo needs to be installed or reinstalled
+  set_fact:
+    odoo_install_required: >-
+      (odoo_role_desired_tar_download.changed) or
+      (odoo_role_desired_git_download.changed) or
+      (odoo_package_not_installed) or
+      (odoo_role_force_install | default(false))
 
 - name: Install Odoo
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -144,7 +144,7 @@
   become: true
   become_user: "{{ odoo_role_odoo_user }}"
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
-  when: odoo_role_desired_tar_download.changed or odoo_role_desired_git_download.changed or odoo_package_is_installed.rc == 1
+  when: odoo_install_required
 
 - name: Populate community db modules
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -123,7 +123,7 @@
   become: true
   become_user: "{{ odoo_role_odoo_user }}"
   ansible.builtin.shell: >
-    {{ odoo_role_odoo_python_path }} -m pip list | grep odoo
+    {{ odoo_role_odoo_python_path }} -m pip show odoo
   register: odoo_package_is_installed
   failed_when: odoo_package_is_installed.rc not in [0,1]
 
@@ -131,7 +131,7 @@
   become: true
   become_user: "{{ odoo_role_odoo_user }}"
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
-  when: odoo_role_desired_tar_download.changed or odoo_role_desired_git_download.changed or odoo_package_is_installed.stdout == ''
+  when: odoo_role_desired_tar_download.changed or odoo_role_desired_git_download.changed or odoo_package_is_installed.rc == 1
 
 - name: Populate community db modules
   set_fact:

--- a/templates/requirements.txt.j2
+++ b/templates/requirements.txt.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+{% for package in odoo_role_odoo_community_packages|default([]) %}
+{{ package }}
+{% endfor %}
+
+{% for package in odoo_role_odoo_project_packages|default([]) %}
+{{ package }}
+{% endfor %}


### PR DESCRIPTION
Right now we blindly [copy](https://github.com/coopdevs/odoo-role/blob/master/tasks/community-modules.yml#L3) a text file to generate the `requirement.txt` file needed to install all the Python packages we need in our projects.

In some case we need to change the content of `requirement.txt` based on many possibles ways (as many as Ansible variables allow).

An example is when we want to install a package directly from our local development environment file system meanwhile in staging or production we still want those packages downloaded from Pypi. 

With this PR we introduce 3 new variables:

1. `odoo_role_odoo_community_packages`: packages with Odoo modules that are mere dependencies of our project, we don't develop directly on them
1. `odoo_role_odoo_project_packages`: Odoo modules that we develop for a specific project (classic Odoo custom module, etc)

### TODO

- [x] [Create `requirements.txt` file from template](https://github.com/coopdevs/odoo-role/commit/d4d6056a457df4b36a5b21363c02f76746181425)
- [x] [Install odoo package if not installed in virtualenv](https://github.com/coopdevs/odoo-role/commit/ce3d67462187e677486c5abca846839409ce6441) (useful when you delete the virtualenv to install packages from scratch)
- [x] Make it backward compatible
- [x] Update documentation

### Usage example

https://git.coopdevs.org/coopdevs/comunitats-energetiques/odoo-ce-inventory/-/merge_requests/61
:warning: To test this PR with the Som Comunitats inventory you need to upgrade `pip` package to a version > 20 :warning: 
(this warning doesn't affect how this PR works, is just related to Som Comunitats needs, you can test this PR with other configurations)