### PR TITLE
feat: bump to Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Role Variables
 --------------
 Available variables are listed below, along with default values:
 
+* Python VirtualEnv
+
+```yaml
+odoo_role_python_version: "3.8.17"
+odoo_role_venv_name: "odoo"
+odoo_role_odoo_venv_path: "/home/{{ odoo_role_odoo_user }}/pyenv/versions/{{ odoo_role_venv_name }}/"
+```
+
 * Edition
 
 This role supports installing Odoo following two different strategies: `git` (from a git repository) and `tar` (a package or compressed release file).

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Community Roles
 #### Deploy
 To use community roles, you need to deploy this modules in the server. This role manage the modules deployment with `pip`.
 
-You can define a `requirements.txt` file to manage the modules and ensure the version installed:
+You can define a `requirements.txt` file to manage the modules and ensure the version installed with:
 
 ```
 # requirements.txt
@@ -255,6 +255,7 @@ odoo11-addon-contract-variable-quantity==11.0.1.2.1
 ```
 
 > The default the `requirements.txt` file path is `"{{ inventory_dir }}/../files/requirements.txt"`.
+> You can choose a different one by setting `odoo_role_community_modules_requirements_path` variable.
 
 # Install
 Once the modules are in the server, you need to install them in the database.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Available variables are listed below, along with default values:
 ```yaml
 odoo_role_python_version: "3.8.17"
 odoo_role_venv_name: "odoo"
-odoo_role_odoo_venv_path: "/home/{{ odoo_role_odoo_user }}/pyenv/versions/{{ odoo_role_venv_name }}/"
 ```
 
 * Edition

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@ An Odoo Ansible Provisioning Role
 =========================================
 
 This an Ansible role for provisioning Odoo. It supports:
+* Odoo 14
+* Odoo 13
 * Odoo 12
 * Odoo 11
 * Odoo 10
 
-I has not been tested yet with Odoo 13.
+It has not been production-tested yet with Odoo 15.
 
 Requirements
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ odoo_role_odoo_user: odoo
 odoo_role_odoo_group: odoo
 
 # VirtualEnv vars
-odoo_role_python_version: "3.7.7"
+odoo_role_python_version: "3.8.17"
 odoo_role_venv_name: "odoo"
 odoo_role_odoo_venv_path: "/home/{{ odoo_role_odoo_user }}/pyenv/versions/{{ odoo_role_venv_name }}/"
 


### PR DESCRIPTION
Update default version to 3.8, as 3.7 is EOL.

https://devguide.python.org/versions/#versions