### PR TITLE
Update Virtual Environment Handling for Python Version Changes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -123,7 +123,7 @@
   become: true
   become_user: "{{ odoo_role_odoo_user }}"
   shell: "cd {{ odoo_role_odoo_path }} && {{ odoo_role_odoo_python_path }} setup.py install"
-  when: odoo_role_desired_tar_download.changed or odoo_role_desired_git_download.changed
+  when: odoo_role_desired_tar_download.changed or odoo_role_desired_git_download.changed or (python_version_changed is defined and python_version_changed.changed)
 
 - name: Populate community db modules
   set_fact:

--- a/tasks/pyenv.yml
+++ b/tasks/pyenv.yml
@@ -75,17 +75,38 @@
   become_user: "{{ odoo_role_odoo_user }}"
   shell: . /home/{{ odoo_role_odoo_user }}/pyenv/.pyenvrc && pyenv update
 
+- name: "Check if virtual environment exists"
+  become: true
+  become_user: "{{ odoo_role_odoo_user }}"
+  stat:
+    path: "/home/{{ odoo_role_odoo_user }}/pyenv/versions/{{ odoo_role_venv_name }}/bin/python"
+  register: venv_python
+
+- name: "Check Python version in virtual environment"
+  become: true
+  become_user: "{{ odoo_role_odoo_user }}"
+  shell: "/home/{{ odoo_role_odoo_user }}/pyenv/versions/{{ odoo_role_venv_name }}/bin/python --version"
+  register: python_version
+  when: venv_python.stat.exists
+
+- name: "Delete existing virtual environment with different Python version"
+  become: true
+  become_user: "{{ odoo_role_odoo_user }}"
+  shell: ". /home/{{ odoo_role_odoo_user }}/pyenv/.pyenvrc && pyenv virtualenv-delete -f {{ odoo_role_venv_name }}"
+  register: python_version_changed
+  when: venv_python.stat.exists and (python_version.stdout.split()[1] != odoo_role_python_version)
+
 - name: "Install Python interpreter {{ odoo_role_python_version }}"
   become: true
   become_user: "{{ odoo_role_odoo_user }}"
-  shell: . /home/{{ odoo_role_odoo_user }}/pyenv/.pyenvrc && pyenv install {{ odoo_role_python_version }}
+  shell: ". /home/{{ odoo_role_odoo_user }}/pyenv/.pyenvrc && pyenv install {{ odoo_role_python_version }}"
   args:
     creates: "/home/{{ odoo_role_odoo_user }}/pyenv/versions/{{ odoo_role_python_version }}/bin/python"
 
 - name: "Create virtual environment {{ odoo_role_venv_name }}"
   become: true
   become_user: "{{ odoo_role_odoo_user }}"
-  shell: . /home/{{ odoo_role_odoo_user }}/pyenv/.pyenvrc && pyenv virtualenv {{ odoo_role_python_version  }} {{ odoo_role_venv_name }}
+  shell: ". /home/{{ odoo_role_odoo_user }}/pyenv/.pyenvrc && pyenv virtualenv {{ odoo_role_python_version }} {{ odoo_role_venv_name }}"
   args:
     creates: "/home/{{ odoo_role_odoo_user }}/pyenv/versions/{{ odoo_role_venv_name }}/bin/python"
 


### PR DESCRIPTION
Without these steps, changing the Python version would not affect the existing virtual environment (`venv`).

When the `venv` is destroyed, it becomes necessary to reinstall Odoo.

Therefore, our first action is to check for the presence of an existing `venv`. If found, we verify its Python version. If this version does not match our desired one, we proceed to remove the virtualenv.

Additionally, in the `when` conditions for the Odoo installation task, we now include a check to determine if the `venv` was recently deleted.




