### PR TITLE
Add task to disable mail servers and cron in test dbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,25 @@ environment_variables:
 
 This option add a file in `/etc/default/odoo` with the vars and add to the Systemd service the `EnvironmentFile` attribute pointing to `/etc/default/odoo.
 
+* Test databases
+
+The array `odoo_role_test_dbs` contains the names of the test databases.
+
+```yaml
+odoo_role_test_dbs: []
+```
+
+By default, the role will perform some actions to test databases:
+
+- If `web_environment_ribbon` module is present, it will be activated with the name of the DB.
+- Mail servers and scheduled actions will be disabled.
+
+Last one can be disabled setting `odoo_role_disable_mail_on_test_dbs` variable to `false`.
+
+```yaml
+odoo_role_disable_mail_on_test_dbs: true
+```
+
 Role Tags
 ---------------
 #### Using the `only-modules` Tag

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -116,3 +116,6 @@ odoo_role_logrotate_odoo:
 wkhtmltox_version_jammy: "0.12.6.1-2"
 wkhtmltox_version_bionic: "0.12.6-1"
 wkhtmltox_version: "{% if ansible_distribution_release in ['jammy', 'bullseye'] %}{{ wkhtmltox_version_jammy }}{% else %}{{wkhtmltox_version_bionic}}{% endif %}"
+
+# disable mail servers
+odoo_role_disable_mail_on_test_dbs: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -322,6 +322,19 @@
   notify: restart odoo
   tags: ['only-modules']
 
+- name: Disable mail servers and cron for test dbs
+  become: true
+  become_user: "{{ odoo_role_odoo_user }}"
+  command: >
+    psql
+    -d {{ item }}
+    -c "UPDATE ir_mail_server SET active='f'; UPDATE fetchmail_server SET active='f'; UPDATE ir_cron SET active='f';
+  when:
+    - item in odoo_role_test_dbs and odoo_role_disable_mail_on_test_dbs
+  with_items: "{{ odoo_role_odoo_dbs }}"
+  notify: restart odoo
+  tags: ['only-modules']
+
 - name: Disable ribbon name for prod dbs
   become: true
   become_user: "{{ odoo_role_odoo_user }}"


### PR DESCRIPTION
This intends to automate the archiving of mail servers and scheduled actions on test databases.

I am not thrilled with this solution, as it does not prevent anything if we restore a production database.

I think we should go towards some kind of solution that does not depend on the db, but on the environment. And for this, we should run two different processes, with two independent configuration files and virtualenvs.

With this setup, we would be able to use the modules from the [server-env](https://github.com/OCA/server-env/tree/14.0) repository.

