### PR TITLE
fix: add default value to db_port in conf template

### DIFF
--- a/templates/odoo.conf.j2
+++ b/templates/odoo.conf.j2
@@ -31,7 +31,7 @@ list_db = True
 list_db = {{ odoo_role_list_db }}
 {% endif %}
 
-{% if odoo_role_db_port %}
+{% if odoo_role_db_port | default(False) %}
 db_port = {{ odoo_role_db_port }}
 {% endif %}
 


### PR DESCRIPTION
If not defined, Ansible crashes.

Fixes #161