### PR TITLE
pip loop via Ansible' squash_actions is deprecated

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -339,14 +339,13 @@
   become: true
   become_user: "{{ odoo_role_odoo_user }}"
   pip:
-    name: "{{ item }}"
+    name:
+      - pytest
+      - pytest-odoo
+      - coverage
+      - watchdog
     virtualenv: "{{ odoo_role_odoo_venv_path }}"
   when: odoo_role_dev_mode | bool
-  with_items:
-    - pytest
-    - pytest-odoo
-    - coverage
-    - watchdog
 
 - import_tasks: add-service.yml
   when: not odoo_role_dev_mode | bool


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "pip" only once while using a loop via 
squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: "{{ item }}"`, please use `name: ['pytest', 'pytest-
odoo', 'coverage', 'watchdog']` and remove the loop. This feature will be 
removed from ansible-base in version 2.11. Deprecation warnings can be disabled
 by setting deprecation_warnings=False in ansible.cfg.
```