### PR TITLE
fix: set pip version compatible with Odoo 12.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,11 @@
     state: present
   when: odoo_role_odoo_version < "13.0"
 
+- name: Set a pip version compatible with 12.0
+  set_fact:
+    odoo_role_pip_version: "19.3.1"
+  when: odoo_role_odoo_version == "12.0" and odoo_role_pip_version is not defined
+
 - name: Check if wkhtmltopdf is installed
   shell: set -o pipefail && dpkg -s wkhtmltox | grep 'install ok installed'
   args:


### PR DESCRIPTION
On 12.0, the greatest valid `pip` version is `19.3.1`.

This PR adds a task to set the right version if  `odoo_role_odoo_version` equals to "12.0" and `odoo_role_pip_version` is not defined.