### PR TITLE
fix: pyenv version installation flag (skip/force)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ odoo_role_odoo_git_url: "https://github.com/OCA/OCB.git"
 odoo_role_odoo_git_ref: "11.0"
 # Variable to define pip version
 odoo_role_pip_version: "23.1.2"
+
+# Variable for force reinstall existing python version in pyenv. When set to false, the role will not reinstall the python version (using `--skip-existing` flag).
+odoo_role_force_pyenv_version: false
 ```
 
 * Users and group
@@ -134,7 +137,7 @@ odoo_role_odoo_community_modules_dict:
 ```
 
 * Force update odoo modules
-In order to force update an odoo module or a list of modules execute provisioning with the command 
+In order to force update an odoo module or a list of modules execute provisioning with the command
 ```
 -e "odoo_role_modules_force_update=['l10n_es']"
 ```
@@ -169,7 +172,7 @@ odoo_role_enable_queue_job: true
 
 This option add to the Odoo configuration file the option to enable queue\_job as a new thread/process: https://github.com/OCA/queue/blob/12.0/queue\_job/README.rst#id12
 
-* Server-wide modules  
+* Server-wide modules
 
 If you need to install some wide-server modules apart from `db_filter` and `queue_job`, use:
 ```yaml
@@ -251,7 +254,7 @@ odoo11-addon-contract-variable-quantity==11.0.1.2.1
 >
 > This allows you to have different `requirements.txt` files and use them on a conditional way.
 >
-> For example, you could set it `{{ inventory_dir }}/../files/requirements-dev.txt` 
+> For example, you could set it `{{ inventory_dir }}/../files/requirements-dev.txt`
 > and use it for dev envs redefining the variable at `host_vars` level.
 
 
@@ -307,7 +310,7 @@ It will provision a virtual machine with postgresql and then, execute the role.
 Release
 -------
 
-To publish a new release: 
+To publish a new release:
 - Go to [releases](https://github.com/coopdevs/odoo-role/releases) and click  on `Draft a new release`.
 - Create a new tag on `Choose a tag` and update the description with the changelog, as the example below:
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ odoo_role_odoo_group: odoo
 
 # VirtualEnv vars
 odoo_role_python_version: "3.7.7"
+odoo_role_force_pyenv_version: False
+odoo_role_pyenv_extra_args: "--skip-existing"
 odoo_role_venv_name: "odoo"
 odoo_role_odoo_venv_path: "/home/{{ odoo_role_odoo_user }}/pyenv/versions/{{ odoo_role_venv_name }}/"
 

--- a/tasks/pyenv.yml
+++ b/tasks/pyenv.yml
@@ -75,10 +75,15 @@
   become_user: "{{ odoo_role_odoo_user }}"
   shell: . /home/{{ odoo_role_odoo_user }}/pyenv/.pyenvrc && pyenv update
 
+- name: "Set force or skip if pyenv version is already installed"
+  set_fact:
+    odoo_role_pyenv_extra_args: "--force"
+  when: odoo_role_force_pyenv_version == True | default(False)
+
 - name: "Install Python interpreter {{ odoo_role_python_version }}"
   become: true
   become_user: "{{ odoo_role_odoo_user }}"
-  shell: . /home/{{ odoo_role_odoo_user }}/pyenv/.pyenvrc && pyenv install {{ odoo_role_python_version }}
+  shell: . /home/{{ odoo_role_odoo_user }}/pyenv/.pyenvrc && pyenv install {{ odoo_role_pyenv_extra_args }} {{ odoo_role_python_version }}
   args:
     creates: "/home/{{ odoo_role_odoo_user }}/pyenv/versions/{{ odoo_role_python_version }}/bin/python"
 


### PR DESCRIPTION
If the version defined for pyenv is already installed, playbook will stuck expecting for user input:

```bash
(odoo) odoo@odoo:~/pyenv$ pyenv install 3.8
pyenv: /home/odoo/pyenv/versions/3.8.19 already exists
continue with installation? (y/N) n 
```

There are two flags for handling this:

```bash
  -f/--force         Install even if the version appears to be installed already
  -s/--skip-existing Skip if the version appears to be installed already
```


This PR set the `-s` flag by default and allows to force reinstall by setting `odoo_role_force_pyenv_version` to `True`