### PR TITLE
Add --no-http to init DBs task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -221,6 +221,7 @@
     {% endif %}
     --logfile=/dev/stdout
     --log-level=warn
+    --no-http
   when: db_initialized.results[index].stdout == "0"
   notify: restart odoo
   with_items: "{{ odoo_role_odoo_dbs }}"


### PR DESCRIPTION
This change avoid the error: `address already in use` when we are trying to create a new DB in an instance with multi DB.